### PR TITLE
use public vm images for all but the signed build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,7 @@ jobs:
     - job: Windows_NT
       pool:
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCorePublic-Int-Pool
-          queue: buildpool.windows.10.amd64.vs2017.open
+          vmImage: windows-2019
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           name: NetCoreInternal-Int-Pool
           queue: buildpool.windows.10.amd64.vs2017
@@ -109,12 +108,7 @@ jobs:
     jobs:
     - job: Linux
       pool:
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCorePublic-Int-Pool
-          queue: buildpool.ubuntu.1604.amd64.open
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCoreInternal-Int-Pool
-          queue: buildpool.ubuntu.1604.amd64
+        vmImage: ubuntu-16.04
       variables:
       # Enable signing for internal, non-PR builds
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
This is an attempt to get around the issue where PRs wait forever trying to get a machine; this seems to work well in the `dotnet/fsharp` repo.