### PR TITLE
Add --port option to dotnet try

### DIFF
--- a/MLS.Agent.Tests/AgentService.cs
+++ b/MLS.Agent.Tests/AgentService.cs
@@ -45,6 +45,8 @@ namespace MLS.Agent.Tests
 
         private TestServer CreateTestServer()
         {
+            //We need to set the feature collection to be not null,
+            //so that the ServerFeatures(like the urls to use) can be configured and used
             var featureCollection = new FeatureCollection();
             featureCollection.Set<IServerAddressesFeature>(new ServerAddressesFeature());
             return new TestServer(CreateWebHostBuilder(), featureCollection);

--- a/MLS.Agent.Tests/AgentService.cs
+++ b/MLS.Agent.Tests/AgentService.cs
@@ -70,7 +70,7 @@ namespace MLS.Agent.Tests
                           })
                           .UseTestEnvironment()
                           .UseStartup<Startup>()
-                          .WithConfiguredApplicationUrl(_options);
+                          .ConfigureUrlUsingPort(_options.Port);
 
             return builder;
         }

--- a/MLS.Agent.Tests/AgentService.cs
+++ b/MLS.Agent.Tests/AgentService.cs
@@ -68,7 +68,7 @@ namespace MLS.Agent.Tests
                           })
                           .UseTestEnvironment()
                           .UseStartup<Startup>()
-                          .WithConfigureApplicationUrl(_options);
+                          .WithConfiguredApplicationUrl(_options);
 
             return builder;
         }

--- a/MLS.Agent.Tests/AgentService.cs
+++ b/MLS.Agent.Tests/AgentService.cs
@@ -53,7 +53,6 @@ namespace MLS.Agent.Tests
         private IWebHostBuilder CreateWebHostBuilder()
         {
             var builder = new WebHostBuilder()
-                          .UseUrls("http://localhost:4242")
                           .ConfigureServices(c =>
                           {
                               if (_directoryAccessor != null)
@@ -68,7 +67,8 @@ namespace MLS.Agent.Tests
                               });
                           })
                           .UseTestEnvironment()
-                          .UseStartup<Startup>();
+                          .UseStartup<Startup>()
+                          .WithConfigureApplicationUrl(_options);
 
             return builder;
         }

--- a/MLS.Agent.Tests/AgentService.cs
+++ b/MLS.Agent.Tests/AgentService.cs
@@ -5,6 +5,8 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using MLS.Agent.CommandLine;
@@ -41,11 +43,17 @@ namespace MLS.Agent.Tests
 
         public void Dispose() => _disposables.Dispose();
 
-        private TestServer CreateTestServer() => new TestServer(CreateWebHostBuilder());
+        private TestServer CreateTestServer()
+        {
+            var featureCollection = new FeatureCollection();
+            featureCollection.Set<IServerAddressesFeature>(new ServerAddressesFeature());
+            return new TestServer(CreateWebHostBuilder(), featureCollection);
+        }
 
         private IWebHostBuilder CreateWebHostBuilder()
         {
             var builder = new WebHostBuilder()
+                          .UseUrls("http://localhost:4242")
                           .ConfigureServices(c =>
                           {
                               if (_directoryAccessor != null)

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -224,10 +224,10 @@ namespace MLS.Agent.Tests.CommandLine
         [Fact]
         public void Negative_port_fails_the_parse()
         {
-            _parser.Parse("--port -1")
+            _parser.Parse("--port -8090")
                    .Errors
                    .Should()
-                   .Contain(e => e.Message == "Invalid argument for --port. Negative port number is not allowed");
+                   .Contain(e => e.Message == "Invalid argument for --port option");
         }
 
         [Fact]

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -222,7 +222,7 @@ namespace MLS.Agent.Tests.CommandLine
         }
 
         [Fact]
-        public async Task Takes_5000_as_the_default_port()
+        public async Task Takes_9000_as_the_default_port()
         {
             await _parser.InvokeAsync("", _console);
             _start_options.Port.Should().Be(5000);

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -220,7 +220,16 @@ namespace MLS.Agent.Tests.CommandLine
             await _parser.InvokeAsync("--port 6000", _console);
             _start_options.Port.Should().Be(6000);
         }
-        
+
+        [Fact]
+        public void Negative_port_fails_the_parse()
+        {
+            _parser.Parse("--port -1")
+                   .Errors
+                   .Should()
+                   .Contain(e => e.Message == "Invalid argument for --port. Negative port number is not allowed");
+        }
+
         [Fact]
         public void Parse_application_insights_key_without_parameter_fails_the_parse()
         {

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -222,6 +222,13 @@ namespace MLS.Agent.Tests.CommandLine
         }
 
         [Fact]
+        public async Task Takes_5000_as_the_default_port()
+        {
+            await _parser.InvokeAsync("", _console);
+            _start_options.Port.Should().Be(5000);
+        }
+
+        [Fact]
         public void Parse_application_insights_key_without_parameter_fails_the_parse()
         {
             var result = _parser.Parse("hosted --ai-key");

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -222,10 +222,10 @@ namespace MLS.Agent.Tests.CommandLine
         }
 
         [Fact]
-        public async Task Takes_9000_as_the_default_port()
+        public async Task Takes_1517_as_the_default_port()
         {
             await _parser.InvokeAsync("", _console);
-            _start_options.Port.Should().Be(5000);
+            _start_options.Port.Should().Be(1517);
         }
 
         [Fact]

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -215,6 +215,13 @@ namespace MLS.Agent.Tests.CommandLine
         }
 
         [Fact]
+        public async Task Parses_the_port()
+        {
+            await _parser.InvokeAsync("--port 6000", _console);
+            _start_options.Port.Should().Be(6000);
+        }
+
+        [Fact]
         public void Parse_application_insights_key_without_parameter_fails_the_parse()
         {
             var result = _parser.Parse("hosted --ai-key");

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -218,16 +218,9 @@ namespace MLS.Agent.Tests.CommandLine
         public async Task Parses_the_port()
         {
             await _parser.InvokeAsync("--port 6000", _console);
-            _start_options.Port.Should().Be(6000);
+            _start_options.Port.Should().Be("6000");
         }
-
-        [Fact]
-        public async Task Takes_1517_as_the_default_port()
-        {
-            await _parser.InvokeAsync("", _console);
-            _start_options.Port.Should().Be(1517);
-        }
-
+        
         [Fact]
         public void Parse_application_insights_key_without_parameter_fails_the_parse()
         {

--- a/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
+++ b/MLS.Agent.Tests/CommandLine/CommandLineParserTests.cs
@@ -218,7 +218,7 @@ namespace MLS.Agent.Tests.CommandLine
         public async Task Parses_the_port()
         {
             await _parser.InvokeAsync("--port 6000", _console);
-            _start_options.Port.Should().Be("6000");
+            _start_options.Port.Should().Be(6000);
         }
         
         [Fact]

--- a/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
+++ b/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using System.Net;
+using Xunit;
+namespace MLS.Agent.Tests
+{
+    public class WebHostBuilderExtensionTests
+    {
+        [Fact]
+        public void If_launched_for_development_4242_is_used()
+        {
+            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(true, null);
+            uri.ToString().Should().Be("http://localhost:4242/");
+        }
+
+        [Fact]
+        public void If_not_launched_for_development_and_port_is_specified_it_is_used()
+        {
+            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, 6000);
+            uri.ToString().Should().Be("https://localhost:6000/");
+        }
+
+        [Fact]
+        public void If_not_launched_for_development_and_port_is_not_specified_a_free_port_is_returned()
+        {
+            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, null);
+            uri.AbsoluteUri.Should().Match("https://localhost:*/");
+            uri.Port.Should().Be(6000);
+        }
+    }
+}

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -184,7 +184,7 @@ namespace MLS.Agent.CommandLine
                 command.AddOption(new Option(
                                         "--port",
                                         "Specify the port for dotnet try to listen on",
-                                        new Argument<int>(9000)));
+                                        new Argument<int>(1517)));
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -184,7 +184,7 @@ namespace MLS.Agent.CommandLine
                 command.AddOption(new Option(
                                         "--port",
                                         "Specify the port for dotnet try to listen on",
-                                        new Argument<int>()));
+                                        new Argument<int>(9000)));
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -183,7 +183,7 @@ namespace MLS.Agent.CommandLine
 
                 command.AddOption(new Option(
                                         "--port",
-                                        "Specify the port to launch the dotnet try process",
+                                        "Specify the port for dotnet try to listen on",
                                         new Argument<int>()));
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -6,6 +6,7 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Clockwise;
 using Microsoft.AspNetCore.Hosting;
@@ -53,7 +54,7 @@ namespace MLS.Agent.CommandLine
             IConsole console,
             StartServer startServer = null,
             InvocationContext context = null);
-     
+
         public static Parser Create(
             StartServer startServer = null,
             Demo demo = null,
@@ -91,8 +92,8 @@ namespace MLS.Agent.CommandLine
             pack = pack ??
                    PackCommand.Do;
 
-             install = install??
-              InstallCommand.Do;
+            install = install ??
+             InstallCommand.Do;
             services = services ??
              new ServiceCollection();
 
@@ -181,10 +182,29 @@ namespace MLS.Agent.CommandLine
                                       "Enable verbose logging to the console",
                                       new Argument<bool>()));
 
+                var portArgument = new Argument<int>()
+                {
+                    Arity = ArgumentArity.ZeroOrOne,
+                };
+
+                portArgument.AddValidator(symbolResult =>
+                {
+                    if (symbolResult.Tokens.Count == 1)
+                    {
+                        var portNumber = Int64.Parse(symbolResult.Tokens.Single().Value);
+                        if (portNumber < 0)
+                        {
+                            return "Invalid argument for --port. Negative port number is not allowed";
+                        }
+                    }
+
+                    return null;
+                });
+
                 command.AddOption(new Option(
                                         "--port",
                                         "Specify the port for dotnet try to listen on",
-                                        new Argument<int>()));
+                                        portArgument));
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {
@@ -250,7 +270,7 @@ namespace MLS.Agent.CommandLine
             Command Demo()
             {
                 var demoCommand = new Command(
-                    "demo", 
+                    "demo",
                     "Learn how to create Try .NET content with an interactive demo")
                 {
                     new Option("--output", "Where should the demo project be written to?")
@@ -283,15 +303,15 @@ namespace MLS.Agent.CommandLine
 
                 return github;
             }
-            
+
             Command Jupyter()
             {
                 var jupyterCommand = new Command("jupyter", "Starts dotnet try as a Jupyter kernel");
                 jupyterCommand.IsHidden = true;
                 var connectionFileArgument = new Argument<FileInfo>
-                                             {
-                                                 Name = "ConnectionFile"
-                                             }.ExistingOnly();
+                {
+                    Name = "ConnectionFile"
+                }.ExistingOnly();
                 jupyterCommand.Argument = connectionFileArgument;
 
                 jupyterCommand.Handler = CommandHandler.Create<JupyterOptions, IConsole, InvocationContext>((options, console, context) =>

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -181,6 +181,11 @@ namespace MLS.Agent.CommandLine
                                       "Enable verbose logging to the console",
                                       new Argument<bool>()));
 
+                command.AddOption(new Option(
+                                        "--port",
+                                        "Specify the port to launch the dotnet try process",
+                                        new Argument<int>()));
+
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {
                     services.AddSingleton(_ => PackageRegistry.CreateForTryMode(

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -184,7 +184,7 @@ namespace MLS.Agent.CommandLine
                 command.AddOption(new Option(
                                         "--port",
                                         "Specify the port for dotnet try to listen on",
-                                        new Argument<string>()));
+                                        new Argument<int>()));
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -182,20 +182,15 @@ namespace MLS.Agent.CommandLine
                                       "Enable verbose logging to the console",
                                       new Argument<bool>()));
 
-                var portArgument = new Argument<int>()
-                {
-                    Arity = ArgumentArity.ZeroOrOne,
-                };
+                var portArgument = new Argument<ushort>();
 
-                portArgument.AddValidator(symbolResult =>
-                {
-                    if (symbolResult.Tokens.Count == 1)
+                portArgument.AddValidator(symbolResult =>{
+                    
+                    if(symbolResult.Tokens
+                    .Select(t => t.Value)
+                    .Where(value => !ushort.TryParse(value, out ushort result)).Count() >0)
                     {
-                        var portNumber = Int64.Parse(symbolResult.Tokens.Single().Value);
-                        if (portNumber < 0)
-                        {
-                            return "Invalid argument for --port. Negative port number is not allowed";
-                        }
+                        return "Invalid argument for --port option";
                     }
 
                     return null;

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -184,7 +184,7 @@ namespace MLS.Agent.CommandLine
                 command.AddOption(new Option(
                                         "--port",
                                         "Specify the port for dotnet try to listen on",
-                                        new Argument<int>(1517)));
+                                        new Argument<string>()));
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {

--- a/MLS.Agent/CommandLine/StartupOptions.cs
+++ b/MLS.Agent/CommandLine/StartupOptions.cs
@@ -43,7 +43,7 @@ namespace MLS.Agent.CommandLine
             string package = null,
             string packageVersion = null,
             ParseResult parseResult = null,
-            string port = null)
+            int? port = null)
         {
             _parseResult = parseResult;
             LogPath = logPath;
@@ -100,6 +100,6 @@ namespace MLS.Agent.CommandLine
         public string Package { get; }
 
         public string PackageVersion { get; }
-        public string Port { get; }
+        public int? Port { get; }
     }
 }

--- a/MLS.Agent/CommandLine/StartupOptions.cs
+++ b/MLS.Agent/CommandLine/StartupOptions.cs
@@ -43,7 +43,7 @@ namespace MLS.Agent.CommandLine
             string package = null,
             string packageVersion = null,
             ParseResult parseResult = null,
-            int? port = null)
+            ushort? port = null)
         {
             _parseResult = parseResult;
             LogPath = logPath;
@@ -100,6 +100,6 @@ namespace MLS.Agent.CommandLine
         public string Package { get; }
 
         public string PackageVersion { get; }
-        public int? Port { get; }
+        public ushort? Port { get; }
     }
 }

--- a/MLS.Agent/CommandLine/StartupOptions.cs
+++ b/MLS.Agent/CommandLine/StartupOptions.cs
@@ -43,7 +43,7 @@ namespace MLS.Agent.CommandLine
             string package = null,
             string packageVersion = null,
             ParseResult parseResult = null,
-            int port = 9000)
+            int port = 1517)
         {
             _parseResult = parseResult;
             LogPath = logPath;

--- a/MLS.Agent/CommandLine/StartupOptions.cs
+++ b/MLS.Agent/CommandLine/StartupOptions.cs
@@ -42,7 +42,8 @@ namespace MLS.Agent.CommandLine
             bool enablePreviewFeatures = false,
             string package = null,
             string packageVersion = null,
-            ParseResult parseResult = null)
+            ParseResult parseResult = null,
+            int port = 5000)
         {
             _parseResult = parseResult;
             LogPath = logPath;
@@ -59,6 +60,7 @@ namespace MLS.Agent.CommandLine
             EnablePreviewFeatures = enablePreviewFeatures;
             Package = package;
             PackageVersion = packageVersion;
+            Port = port;
         }
 
         public bool EnablePreviewFeatures { get; }
@@ -98,5 +100,6 @@ namespace MLS.Agent.CommandLine
         public string Package { get; }
 
         public string PackageVersion { get; }
+        public int Port { get; }
     }
 }

--- a/MLS.Agent/CommandLine/StartupOptions.cs
+++ b/MLS.Agent/CommandLine/StartupOptions.cs
@@ -43,7 +43,7 @@ namespace MLS.Agent.CommandLine
             string package = null,
             string packageVersion = null,
             ParseResult parseResult = null,
-            int port = 1517)
+            string port = null)
         {
             _parseResult = parseResult;
             LogPath = logPath;
@@ -100,6 +100,6 @@ namespace MLS.Agent.CommandLine
         public string Package { get; }
 
         public string PackageVersion { get; }
-        public int Port { get; }
+        public string Port { get; }
     }
 }

--- a/MLS.Agent/CommandLine/StartupOptions.cs
+++ b/MLS.Agent/CommandLine/StartupOptions.cs
@@ -43,7 +43,7 @@ namespace MLS.Agent.CommandLine
             string package = null,
             string packageVersion = null,
             ParseResult parseResult = null,
-            int port = 5000)
+            int port = 9000)
         {
             _parseResult = parseResult;
             LogPath = logPath;

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -120,7 +120,7 @@ namespace MLS.Agent
                 Log.Trace("Received Key: {key}", options.Key);
             }
 
-           var uri = IsInToolMode()
+           var uri = IsLaunchedForDevelopment()
                           ? new Uri("http://localhost:4242")
                           : new Uri($"http://localhost:{options.Port}");
 
@@ -149,7 +149,7 @@ namespace MLS.Agent
             return webHost;
         }
 
-        private static bool IsInToolMode()
+        private static bool IsLaunchedForDevelopment()
         {
             var processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
             return processName == "dotnet" || processName == "dotnet.exe";

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -140,7 +140,7 @@ namespace MLS.Agent
                           })
                           .UseEnvironment(options.EnvironmentName)
                           .UseStartup<Startup>()
-                          .WithConfigureApplicationUrl(options)
+                          .WithConfiguredApplicationUrl(options)
                           .Build();
 
             return webHost;

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -122,7 +122,7 @@ namespace MLS.Agent
 
            var uri = IsLaunchedForDevelopment()
                           ? new Uri("http://localhost:4242")
-                          : new Uri($"http://localhost:{options.Port}");
+                          : new Uri($"https://localhost:{options.Port}");
 
             var webHost = new WebHostBuilder()
                           .UseKestrel()

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -120,9 +120,6 @@ namespace MLS.Agent
                 Log.Trace("Received Key: {key}", options.Key);
             }
 
-           var uri = IsLaunchedForDevelopment()
-                          ? new Uri("http://localhost:4242")
-                          : new Uri($"https://localhost:{options.Port}");
 
             var webHost = new WebHostBuilder()
                           .UseKestrel()
@@ -143,16 +140,10 @@ namespace MLS.Agent
                           })
                           .UseEnvironment(options.EnvironmentName)
                           .UseStartup<Startup>()
-                          .UseUrls(uri.ToString())
+                          .WithConfigureApplicationUrl(options)
                           .Build();
 
             return webHost;
-        }
-
-        private static bool IsLaunchedForDevelopment()
-        {
-            var processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
-            return processName == "dotnet" || processName == "dotnet.exe";
         }
     }
 }

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -140,7 +140,7 @@ namespace MLS.Agent
                           })
                           .UseEnvironment(options.EnvironmentName)
                           .UseStartup<Startup>()
-                          .WithConfiguredApplicationUrl(options)
+                          .ConfigureUrlUsingPort(options.Port)
                           .Build();
 
             return webHost;

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -120,6 +120,13 @@ namespace MLS.Agent
                 Log.Trace("Received Key: {key}", options.Key);
             }
 
+            var processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+
+            var uri = processName == "dotnet" ||
+                      processName == "dotnet.exe"
+                          ? new Uri("http://localhost:4242")
+                          : new Uri($"http://localhost:{options.Port}");
+
             var webHost = new WebHostBuilder()
                           .UseKestrel()
                           .UseContentRoot(Directory.GetCurrentDirectory())
@@ -139,6 +146,7 @@ namespace MLS.Agent
                           })
                           .UseEnvironment(options.EnvironmentName)
                           .UseStartup<Startup>()
+                          .UseUrls(uri.ToString())
                           .Build();
 
             return webHost;

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -120,10 +120,7 @@ namespace MLS.Agent
                 Log.Trace("Received Key: {key}", options.Key);
             }
 
-            var processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
-
-            var uri = processName == "dotnet" ||
-                      processName == "dotnet.exe"
+           var uri = IsInToolMode()
                           ? new Uri("http://localhost:4242")
                           : new Uri($"http://localhost:{options.Port}");
 
@@ -150,6 +147,12 @@ namespace MLS.Agent
                           .Build();
 
             return webHost;
+        }
+
+        private static bool IsInToolMode()
+        {
+            var processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+            return processName == "dotnet" || processName == "dotnet.exe";
         }
     }
 }

--- a/MLS.Agent/Startup.cs
+++ b/MLS.Agent/Startup.cs
@@ -159,10 +159,8 @@ namespace MLS.Agent
             IApplicationLifetime lifetime,
             IBrowserLauncher browserLauncher,
             IDirectoryAccessor directoryAccessor,
-            PackageRegistry packageRegistry,
-            IHttpContextAccessor httpContextAccessor)
+            PackageRegistry packageRegistry)
         {
-            _httpContextAccessor = httpContextAccessor;
             using (var operation = Log.OnEnterAndConfirmOnExit())
             {
                 lifetime.ApplicationStopping.Register(() => _disposables.Dispose());

--- a/MLS.Agent/Startup.cs
+++ b/MLS.Agent/Startup.cs
@@ -40,6 +40,7 @@ namespace MLS.Agent
         {
             () => Logger<Program>.Log.Event("AgentStopping")
         };
+        private IHttpContextAccessor _httpContextAccessor;
 
         public Startup(
             IHostingEnvironment env,
@@ -155,8 +156,10 @@ namespace MLS.Agent
             IApplicationLifetime lifetime,
             IBrowserLauncher browserLauncher,
             IDirectoryAccessor directoryAccessor,
-            PackageRegistry packageRegistry)
+            PackageRegistry packageRegistry,
+            IHttpContextAccessor httpContextAccessor)
         {
+            _httpContextAccessor = httpContextAccessor;
             using (var operation = Log.OnEnterAndConfirmOnExit())
             {
                 lifetime.ApplicationStopping.Register(() => _disposables.Dispose());
@@ -211,7 +214,7 @@ namespace MLS.Agent
             var uri = processName == "dotnet" ||
                       processName == "dotnet.exe"
                           ? new Uri("http://localhost:4242")
-                          : new Uri("http://localhost:5000");
+                          : new Uri($"http://localhost:{StartupOptions.Port}");
 
             if (StartupOptions.Uri != null &&
                 !StartupOptions.Uri.IsAbsoluteUri)

--- a/MLS.Agent/Startup.cs
+++ b/MLS.Agent/Startup.cs
@@ -207,10 +207,11 @@ namespace MLS.Agent
         private void LaunchBrowser(IBrowserLauncher browserLauncher, IDirectoryAccessor directoryAccessor)
         {
             var processName = Process.GetCurrentProcess().ProcessName;
-            var portToLaunch = processName == "dotnet" ||
-                      processName == "dotnet.exe" ? 4242 : StartupOptions.Port;
 
-            var uri = new Uri($"http://localhost:{portToLaunch}");
+            var uri = processName == "dotnet" ||
+                      processName == "dotnet.exe"
+                          ? new Uri("http://localhost:4242")
+                          : new Uri("http://localhost:5000");
 
             if (StartupOptions.Uri != null &&
                 !StartupOptions.Uri.IsAbsoluteUri)

--- a/MLS.Agent/Startup.cs
+++ b/MLS.Agent/Startup.cs
@@ -41,7 +41,6 @@ namespace MLS.Agent
         {
             () => Logger<Program>.Log.Event("AgentStopping")
         };
-        private IHttpContextAccessor _httpContextAccessor;
 
         public Startup(
             IHostingEnvironment env,
@@ -147,8 +146,6 @@ namespace MLS.Agent
                 {
                     options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All;
                 });
-
-                services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
                 operation.Succeed();
             }

--- a/MLS.Agent/Startup.cs
+++ b/MLS.Agent/Startup.cs
@@ -207,11 +207,10 @@ namespace MLS.Agent
         private void LaunchBrowser(IBrowserLauncher browserLauncher, IDirectoryAccessor directoryAccessor)
         {
             var processName = Process.GetCurrentProcess().ProcessName;
+            var portToLaunch = processName == "dotnet" ||
+                      processName == "dotnet.exe" ? 4242 : StartupOptions.Port;
 
-            var uri = processName == "dotnet" ||
-                      processName == "dotnet.exe"
-                          ? new Uri("http://localhost:4242")
-                          : new Uri("http://localhost:5000");
+            var uri = new Uri($"http://localhost:{portToLaunch}");
 
             if (StartupOptions.Uri != null &&
                 !StartupOptions.Uri.IsAbsoluteUri)

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace MLS.Agent
             }
             else
             {
-                uri = new Uri($"https://localhost:{FreeTcpPort()}");
+                uri = new Uri($"https://localhost:{GetFreePort()}");
             }
 
             return builder.UseUrls(uri.ToString());
@@ -37,7 +37,7 @@ namespace MLS.Agent
             return processName == "dotnet" || processName == "dotnet.exe";
         }
 
-        static int FreeTcpPort()
+        private static int GetFreePort()
         {
             TcpListener l = new TcpListener(IPAddress.Loopback, 0);
             l.Start();

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.AspNetCore.Hosting;
+using MLS.Agent.CommandLine;
+
+namespace MLS.Agent
+{
+    public static class WebHostBuilderExtensions
+    {
+        public static IWebHostBuilder WithConfigureApplicationUrl(this IWebHostBuilder builder, StartupOptions options)
+        {
+            var uri = IsLaunchedForDevelopment()
+                          ? new Uri("http://localhost:4242")
+                          : new Uri($"https://localhost:{options.Port}");
+
+            return builder.UseUrls(uri.ToString());
+        }
+
+        private static bool IsLaunchedForDevelopment()
+        {
+            var processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+            return processName == "dotnet" || processName == "dotnet.exe";
+        }
+    }
+}

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -11,24 +11,26 @@ namespace MLS.Agent
 {
     public static class WebHostBuilderExtensions
     {
-        public static IWebHostBuilder WithConfiguredApplicationUrl(this IWebHostBuilder builder, StartupOptions options)
+        public static IWebHostBuilder ConfigureUrlUsingPort(this IWebHostBuilder builder, int? port)
         {
-            Uri uri;
+            var uri = GetBrowserLaunchUri(IsLaunchedForDevelopment(), port);
+            return builder.UseUrls(uri.ToString());
+        }
 
-            if (IsLaunchedForDevelopment())
+        public static Uri GetBrowserLaunchUri(bool isLaunchedForDevelopment, int? port)
+        {
+            if (isLaunchedForDevelopment)
             {
-                uri = new Uri("http://localhost:4242");
+               return new Uri("http://localhost:4242");
             }
-            else if (options.Port.HasValue)
+            else if (port.HasValue)
             {
-                uri = new Uri($"https://localhost:{options.Port}");
+                return new Uri($"https://localhost:{port}");
             }
             else
             {
-                uri = new Uri($"https://localhost:{GetFreePort()}");
+                return new Uri($"https://localhost:{GetFreePort()}");
             }
-
-            return builder.UseUrls(uri.ToString());
         }
 
         private static bool IsLaunchedForDevelopment()

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace MLS.Agent
             {
                 uri = new Uri("http://localhost:4242");
             }
-            else if (!string.IsNullOrEmpty(options.Port))
+            else if (options.Port.HasValue)
             {
                 uri = new Uri($"https://localhost:{options.Port}");
             }


### PR DESCRIPTION
1. In the Program.cs, based on if we are in tool mode or not we decide the url that will be used.
If we are in tool mode and the user has specified a port, we will use it otherwise we will launch on an available open port.
2. In the Startup.cs we use the `ServerFeatures` property to know the url at which the application is running and then launch the browser on the same when we are in the try mode.