### PR TITLE
enable language as property of workspaces

### DIFF
--- a/DotNetTry.sln.DotSettings
+++ b/DotNetTry.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=trydotnet/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=trydotnet/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Untokenize/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/MLS.Agent.Tests/CommandLine/VerifyCommandTests.cs
+++ b/MLS.Agent.Tests/CommandLine/VerifyCommandTests.cs
@@ -146,7 +146,7 @@ This is some sample code:
                     ("Program.cs", CompilingProgramCs),
                     ("support.fs", "let a = 0"),
                     ("doc.md", @"
-```fs --source-file support.fs
+```fs --source-file support.fs --project some.csproj
 ```
 ")
                 }.CreateFiles();

--- a/MLS.Agent/CommandLine/VerifyCommand.cs
+++ b/MLS.Agent/CommandLine/VerifyCommand.cs
@@ -274,11 +274,11 @@ namespace MLS.Agent.CommandLine
 
         private static bool ProjectIsCompatibleWithLanguage(string projectOrPackageName, string language)
         {
-            var extenstion = Path.GetExtension(projectOrPackageName)?.ToLowerInvariant();
+            var extension = Path.GetExtension(projectOrPackageName)?.ToLowerInvariant();
             var supported = true;
-            if (!string.IsNullOrWhiteSpace(extenstion))
+            if (!string.IsNullOrWhiteSpace(extension))
             {
-                switch (extenstion)
+                switch (extension)
                 {
                     case ".csproj":
                         supported = StringComparer.OrdinalIgnoreCase.Compare(language, "csharp") == 0;

--- a/MLS.Agent/CommandLine/VerifyCommand.cs
+++ b/MLS.Agent/CommandLine/VerifyCommand.cs
@@ -141,7 +141,7 @@ namespace MLS.Agent.CommandLine
                     .Select(b => b.Language())
                     .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
 
-                if (!ProjectIsCompatibleWithLanguage(projectOrPackageName, language))
+                if (!ProjectIsCompatibleWithLanguage( new UriOrFileInfo(projectOrPackageName), language))
                 {
                     SetError();
 
@@ -272,12 +272,12 @@ namespace MLS.Agent.CommandLine
             }
         }
 
-        private static bool ProjectIsCompatibleWithLanguage(string projectOrPackageName, string language)
+        private static bool ProjectIsCompatibleWithLanguage(UriOrFileInfo projectOrPackage, string language)
         {
-            var extension = Path.GetExtension(projectOrPackageName)?.ToLowerInvariant();
             var supported = true;
-            if (!string.IsNullOrWhiteSpace(extension))
+            if (projectOrPackage.IsFile)
             {
+                var extension = projectOrPackage.FileExtension.ToLowerInvariant();
                 switch (extension)
                 {
                     case ".csproj":

--- a/MLS.Agent/MLS.Agent.csproj
+++ b/MLS.Agent/MLS.Agent.csproj
@@ -129,7 +129,8 @@
   <Target Name="BuildCss"
           Inputs="$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Try.Styles\sass\trydotnet.scss"
           Outputs="$(MSBuildThisFileDirectory)wwwroot\css\trydotnet.css"
-          BeforeTargets="BeforeBuild">
+          BeforeTargets="BeforeBuild"
+          Condition="'$(NCrunch)' != '1'">
 
     <PropertyGroup>
       <_TryDotNetCssExists Condition="Exists('$(MSBuildThisFileDirectory)wwwroot\css\trydotnet.css')">true</_TryDotNetCssExists>
@@ -147,7 +148,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GatherInputs">
+  <Target Name="GatherInputs" Condition="'$(NCrunch)' != '1'">
     <PropertyGroup>
       <ClientInputDir>$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Try.Client</ClientInputDir>
       <ClientOutputDir>$(MSBuildThisFileDirectory)wwwroot/client</ClientOutputDir>
@@ -167,7 +168,8 @@
           Inputs="@(TryDotNetJsInput)"
           Outputs="$(TryDotNetJsFile);$(TryDotNetJsMap)"
           DependsOnTargets="GatherInputs"
-          BeforeTargets="BeforeBuild">
+          BeforeTargets="BeforeBuild"
+          Condition="'$(NCrunch)' != '1'">
     <PropertyGroup>
       <_TryDotNetMinJsExists Condition="Exists('$(TryDotNetJsFile)')">true</_TryDotNetMinJsExists>
     </PropertyGroup>
@@ -189,7 +191,8 @@
           Inputs="@(ClientInputFiles)"
           Outputs="$(ClientOutputFile)"
           DependsOnTargets="GatherInputs"
-          BeforeTargets="BeforeBuild">
+          BeforeTargets="BeforeBuild"
+          Condition="'$(NCrunch)' != '1'">
 
     <PropertyGroup>
       <_TryDotNetClientExists Condition="Exists('$(ClientOutputFile)')">true</_TryDotNetClientExists>

--- a/MLS.Agent/MLS.Agent.v3.ncrunchproject
+++ b/MLS.Agent/MLS.Agent.v3.ncrunchproject
@@ -5,6 +5,7 @@
       <Value>..\Microsoft.DotNet.Try.Client\**.*</Value>
       <Value>..\Microsoft.DotNet.Try.js\**.*</Value>
       <Value>..\Microsoft.DotNet.Try.Styles\**.*</Value>
+      <Value>wwwroot\**.*</Value>
     </AdditionalFilesToIncludeForProject>
   </Settings>
 </ProjectConfiguration>

--- a/MLS.Agent/Markdown/AnnotatedCodeBlockExtensions.cs
+++ b/MLS.Agent/Markdown/AnnotatedCodeBlockExtensions.cs
@@ -33,7 +33,7 @@ namespace MLS.Agent.Markdown
         public static string Language(this AnnotatedCodeBlock block)
         {
             return
-                (block.Annotations as LocalCodeBlockAnnotations)?.NormalizedLanguage;
+                block.Annotations?.NormalizedLanguage;
         }
     }
 }

--- a/MLS.Agent/Markdown/AnnotatedCodeBlockExtensions.cs
+++ b/MLS.Agent/Markdown/AnnotatedCodeBlockExtensions.cs
@@ -30,5 +30,10 @@ namespace MLS.Agent.Markdown
                 (block.Annotations as LocalCodeBlockAnnotations)?.Project?.FullName ??
                 block.Annotations?.Package;
         }
+        public static string Language(this AnnotatedCodeBlock block)
+        {
+            return
+                (block.Annotations as LocalCodeBlockAnnotations)?.NormalizedLanguage;
+        }
     }
 }

--- a/Microsoft.DotNet.Try.Client/src/IState.ts
+++ b/Microsoft.DotNet.Try.Client/src/IState.ts
@@ -140,6 +140,7 @@ export interface IWorkspaceState
 
 export interface IWorkspace {
     workspaceType: string;
+    langauge?: string;
     files?: IWorkspaceFile[];
     buffers: IWorkspaceBuffer[];
     usings?: string[];

--- a/Microsoft.DotNet.Try.Client/src/IState.ts
+++ b/Microsoft.DotNet.Try.Client/src/IState.ts
@@ -140,7 +140,7 @@ export interface IWorkspaceState
 
 export interface IWorkspace {
     workspaceType: string;
-    langauge?: string;
+    language?: string;
     files?: IWorkspaceFile[];
     buffers: IWorkspaceBuffer[];
     usings?: string[];

--- a/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlock.cs
+++ b/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlock.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Try.Markdown
 {
     public class AnnotatedCodeBlock : FencedCodeBlock
     {
-        protected readonly List<string> _diagnostics = new List<string>();
+        private readonly List<string> _diagnostics = new List<string>();
         private string _sourceCode;
         private bool _initialized;
 

--- a/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlock.cs
+++ b/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlock.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Try.Markdown
 
             AddAttributeIfNotNull("data-trydotnet-region", annotations.Region);
             AddAttributeIfNotNull("data-trydotnet-session-id", annotations.Session);
-            AddAttribute("class", $"language-{annotations.Language}");
+            AddAttribute("class", $"language-{annotations.NormalizedLanguage}");
         }
 
         public void RenderTo(

--- a/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlockParser.cs
+++ b/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlockParser.cs
@@ -10,12 +10,12 @@ namespace Microsoft.DotNet.Try.Markdown
 {
     public class AnnotatedCodeBlockParser : FencedBlockParserBase<AnnotatedCodeBlock>
     {
-        private readonly CodeFenceAnnotationsParser codeFenceAnnotationsParser;
+        private readonly CodeFenceAnnotationsParser _codeFenceAnnotationsParser;
         private int _order;
 
         public AnnotatedCodeBlockParser(CodeFenceAnnotationsParser codeFenceAnnotationsParser)
         {
-            this.codeFenceAnnotationsParser = codeFenceAnnotationsParser ?? throw new ArgumentNullException(nameof(codeFenceAnnotationsParser));
+            _codeFenceAnnotationsParser = codeFenceAnnotationsParser ?? throw new ArgumentNullException(nameof(codeFenceAnnotationsParser));
             OpeningCharacters = new[] { '`' };
             InfoParser = ParseCodeOptions;
         }
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Try.Markdown
                 return false;
             }
 
-            var result = codeFenceAnnotationsParser.TryParseCodeFenceOptions(line.ToString(),
+            var result = _codeFenceAnnotationsParser.TryParseCodeFenceOptions(line.ToString(),
                 state.Context);
 
             switch (result)

--- a/Microsoft.DotNet.Try.Markdown/CodeBlockAnnotations.cs
+++ b/Microsoft.DotNet.Try.Markdown/CodeBlockAnnotations.cs
@@ -4,6 +4,7 @@
 using System;
 using System.CommandLine;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 
@@ -38,19 +39,23 @@ namespace Microsoft.DotNet.Try.Markdown
             {
                 Session = $"Run{++_sessionIndex}";
             }
+
+            NormalizedLanguage = parseResult?.CommandResult.Name;
+            Language = parseResult?.Tokens.First().Value;
+            RunArgs = runArgs ?? Untokenize(parseResult);
         }
 
         public virtual string Package { get; }
         public RelativeFilePath DestinationFile { get; }
         public string Region { get; }
-        public string RunArgs { get; set; }
+        public string RunArgs { get; }
         public ParseResult ParseResult { get; }
         public string PackageVersion { get; }
         public string Session { get; }
         public bool Editable { get; }
         public bool Hidden { get; }
-        public string Language { get; set; }
-        public string NormalizedLanguage { get; set; }
+        public string Language { get; }
+        public string NormalizedLanguage { get; }
 
         public virtual Task<CodeBlockContentFetchResult> TryGetExternalContent() => 
             Task.FromResult(CodeBlockContentFetchResult.None);
@@ -74,5 +79,15 @@ namespace Microsoft.DotNet.Try.Markdown
 
             return Task.CompletedTask;
         }
+
+        private static string Untokenize(ParseResult result) =>
+            result == null 
+                ? null 
+                : string.Join(" ", result.Tokens
+                    .Select(t => t.Value)
+                    .Skip(1)
+                    .Select(t => Regex.IsMatch(t, @".*\s.*")
+                        ? $"\"{t}\"" 
+                        : t));
     }
 }

--- a/Microsoft.DotNet.Try.Markdown/CodeBlockAnnotations.cs
+++ b/Microsoft.DotNet.Try.Markdown/CodeBlockAnnotations.cs
@@ -5,6 +5,7 @@ using System;
 using System.CommandLine;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace Microsoft.DotNet.Try.Markdown
 {
@@ -49,6 +50,7 @@ namespace Microsoft.DotNet.Try.Markdown
         public bool Editable { get; }
         public bool Hidden { get; }
         public string Language { get; set; }
+        public string NormalizedLanguage { get; set; }
 
         public virtual Task<CodeBlockContentFetchResult> TryGetExternalContent() => 
             Task.FromResult(CodeBlockContentFetchResult.None);
@@ -63,6 +65,11 @@ namespace Microsoft.DotNet.Try.Markdown
             if (PackageVersion != null)
             {
                 block.AddAttribute("data-trydotnet-package-version", PackageVersion);
+            }
+
+            if (!string.IsNullOrWhiteSpace(NormalizedLanguage))
+            {
+                block.AddAttribute("data-trydotnet-language", NormalizedLanguage);
             }
 
             return Task.CompletedTask;

--- a/Microsoft.DotNet.Try.Protocol.ClientApi/Project.cs
+++ b/Microsoft.DotNet.Try.Protocol.ClientApi/Project.cs
@@ -12,12 +12,16 @@ namespace Microsoft.DotNet.Try.Protocol.ClientApi
     [JsonConverter(typeof(ProjectJsonConverter))]
     public class Project : FeatureContainer
     {
+        private const string DefaultLanguage = "csharp";
+
         public string ProjectTemplate { get; }
 
         public SourceFile[] Files { get; }
 
+        public string Language { get; }
 
-        public Project(string projectTemplate, IEnumerable<SourceFile> files)
+
+        public Project(string projectTemplate,  IEnumerable<SourceFile> files, string language = DefaultLanguage)
         {
             if (string.IsNullOrWhiteSpace(projectTemplate))
             {
@@ -39,6 +43,8 @@ namespace Microsoft.DotNet.Try.Protocol.ClientApi
 
             ProjectTemplate = projectTemplate;
 
+            Language = string.IsNullOrWhiteSpace(language) ? DefaultLanguage : language;
+
         }
 
         private class ProjectJsonConverter : FeatureContainerConverter<Project>
@@ -46,6 +52,7 @@ namespace Microsoft.DotNet.Try.Protocol.ClientApi
             protected override void AddProperties(Project container, JObject o)
             {
                 o.Add(new JProperty("projectTemplate", container.ProjectTemplate));
+                o.Add(new JProperty("language", container.Language));
                 o.Add(new JProperty("files", JArray.FromObject(container.Files)));
             }
         }

--- a/Microsoft.DotNet.Try.Protocol/Workspace.cs
+++ b/Microsoft.DotNet.Try.Protocol/Workspace.cs
@@ -4,21 +4,25 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Try.Protocol
 {
     public class Workspace
     {
         private const string DefaultWorkspaceType = "script";
+        private const string DefaultLanguage = "csharp";
 
         public Workspace(
             string[] usings = null,
             File[] files = null,
             Buffer[] buffers = null,
             string workspaceType = DefaultWorkspaceType,
+            string language =  DefaultLanguage,
             bool includeInstrumentation = false)
         {
-            WorkspaceType = workspaceType ?? DefaultWorkspaceType;
+            WorkspaceType = string.IsNullOrWhiteSpace(workspaceType) ? DefaultWorkspaceType : workspaceType;
+            Language = string.IsNullOrWhiteSpace(language) ? DefaultLanguage : language;
             Usings = usings ?? Array.Empty<string>();
             Usings = usings ?? Array.Empty<string>();
             Files = files ?? Array.Empty<File>();
@@ -37,16 +41,24 @@ namespace Microsoft.DotNet.Try.Protocol
             }
         }
 
+        [JsonProperty("language")]
+        public string Language { get; }
+
+        [JsonProperty("files")]
         public File[] Files { get; }
 
+        [JsonProperty("usings")]
         public string[] Usings { get; }
 
+        [JsonProperty("workspaceType")]
         public string WorkspaceType { get; }
 
+        [JsonProperty("includeInstrumentation")]
         public bool IncludeInstrumentation { get; }
 
         [Required]
         [MinLength(1)]
+        [JsonProperty("buffers")]
         public Buffer[] Buffers { get; }
 
         public static Workspace FromSource(

--- a/Microsoft.DotNet.Try.js/src/domInjection/autoEnable.ts
+++ b/Microsoft.DotNet.Try.js/src/domInjection/autoEnable.ts
@@ -213,8 +213,10 @@ function internalAutoEnable(
         let files: SourceFile[] = [];
         let packageName: string = null;
         let packageVersion: string = null;
+        let language: string = "csharp";
         let documentsToOpen: DocumentsToOpen = {};
         let editorCount = -1;
+
         for (let codeSource of session.codeSources) {
             editorCount++;
 
@@ -222,7 +224,6 @@ function internalAutoEnable(
             let code = getCode(codeSource);
 
             let pacakgeAttribute = codeSource.dataset.trydotnetPackage;
-
             if (!isNullOrUndefinedOrWhitespace(pacakgeAttribute)) {
                 packageName = pacakgeAttribute;
             }
@@ -231,6 +232,12 @@ function internalAutoEnable(
             if (!isNullOrUndefinedOrWhitespace(packageVersionAttribute)) {
 
                 packageVersion = packageVersionAttribute;
+            }
+
+            
+            let languageAttribute = codeSource.dataset.trydotnetLanguage;
+            if (!isNullOrUndefinedOrWhitespace(languageAttribute)) {
+                language = languageAttribute;
             }
 
             let editorId = getTrydotnetEditorId(codeSource);
@@ -282,12 +289,16 @@ function internalAutoEnable(
         }
 
         let prj: Project = {
-            package: packageName,
+            package: packageName,            
             files: mergeFiles(files, includes, sessionId)
         };
 
         if (!isNullOrUndefinedOrWhitespace(packageVersion)) {
             prj.packageVersion = packageVersion;
+        }
+
+        if (!isNullOrUndefinedOrWhitespace(language)) {
+            prj.language = language;
         }
 
         let documentsToInclude = getDocumentsToInclude(includes, sessionId);

--- a/Microsoft.DotNet.Try.js/src/internals/workspace.ts
+++ b/Microsoft.DotNet.Try.js/src/internals/workspace.ts
@@ -13,7 +13,7 @@ import { isNullOrUndefined, isNullOrUndefinedOrWhitespace } from "../stringExten
 
 export interface IWorkspace {
     workspaceType: string;
-    langauge?: string;
+    language?: string;
     files?: IWorkspaceFile[];
     buffers?: IWorkspaceBuffer[];
     usings?: string[];
@@ -71,7 +71,7 @@ export class Workspace {
         };
 
         if(!isNullOrUndefinedOrWhitespace(project.language)){
-            this.workspace.langauge = project.language;
+            this.workspace.language = project.language;
         }
 
         if (project.usings) {

--- a/Microsoft.DotNet.Try.js/src/internals/workspace.ts
+++ b/Microsoft.DotNet.Try.js/src/internals/workspace.ts
@@ -13,6 +13,7 @@ import { isNullOrUndefined, isNullOrUndefinedOrWhitespace } from "../stringExten
 
 export interface IWorkspace {
     workspaceType: string;
+    langauge?: string;
     files?: IWorkspaceFile[];
     buffers?: IWorkspaceBuffer[];
     usings?: string[];
@@ -66,8 +67,12 @@ export class Workspace {
 
         this.openDocuments = {};
         this.workspace = {
-            workspaceType: project.package
+            workspaceType: project.package       
         };
+
+        if(!isNullOrUndefinedOrWhitespace(project.language)){
+            this.workspace.langauge = project.language;
+        }
 
         if (project.usings) {
             this.workspace.usings = JSON.parse(JSON.stringify(project.usings));

--- a/Microsoft.DotNet.Try.js/src/project.ts
+++ b/Microsoft.DotNet.Try.js/src/project.ts
@@ -1,9 +1,12 @@
+import { isNullOrUndefinedOrWhitespace } from "./stringExtensions";
+
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export type Project = {
     package: string,
-    packageVersion?:string,
+    packageVersion?: string,
+    language?: string,
     files: SourceFile[],
     [key: string]: any
 };
@@ -18,22 +21,28 @@ export type SourceFileRegion = {
     content: string,
 };
 
-export function createProject(packageName: string, files: SourceFile[], usings?: string[]): Promise<Project> {
-    if (!packageName || packageName.length === 0) {
+export function createProject(args: { packageName: string, files: SourceFile[], usings?: string[], language?: string }): Promise<Project> {
+    if (isNullOrUndefinedOrWhitespace(args.packageName)) {
         throw new Error("packageName can not be null or empty");
     }
 
-    if (!files || files.length === 0) {
+    if (!args.files || args.files.length === 0) {
         throw new Error("at least a file is required");
     }
 
     let project: Project = {
-        package: packageName,
-        files: JSON.parse(JSON.stringify(files))
+        package: args.packageName,
+        files: JSON.parse(JSON.stringify(args.files))
     };
 
-    if (usings) {
-        project.usings = JSON.parse(JSON.stringify(usings));
+    if (isNullOrUndefinedOrWhitespace(args.language)) {
+        project.language = "csharp";
+    } else {
+        project.language = args.language;
+    }
+
+    if (args.usings) {
+        project.usings = JSON.parse(JSON.stringify(args.usings));
     }
 
     return Promise.resolve(project);

--- a/Microsoft.DotNet.Try.js/test/internals/workspace.specs.ts
+++ b/Microsoft.DotNet.Try.js/test/internals/workspace.specs.ts
@@ -30,7 +30,7 @@ describe("a workspace", () => {
         ws.fromProject(project);
         ws.isModified().should.be.true;
         let request = ws.toSetWorkspaceRequests();
-        request.workspace.langauge.should.be.equal("csharp");
+        request.workspace.language.should.be.equal("csharp");
     });
 
     it("is retains the language of hte project", async () => {
@@ -39,7 +39,7 @@ describe("a workspace", () => {
         ws.fromProject(project);
         ws.isModified().should.be.true;
         let request = ws.toSetWorkspaceRequests();
-        request.workspace.langauge.should.be.equal("fsharp");
+        request.workspace.language.should.be.equal("fsharp");
     });
 
     it("is marked as modified when a document is opened", async () => {

--- a/Microsoft.DotNet.Try.js/test/internals/workspace.specs.ts
+++ b/Microsoft.DotNet.Try.js/test/internals/workspace.specs.ts
@@ -19,14 +19,32 @@ describe("a workspace", () => {
 
     it("is marked as modified when propulated from a project", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
-        let project = await createProject("console", [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }]);
+        let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
         ws.fromProject(project);
         ws.isModified().should.be.true;
     });
 
+    it("is should have default language", async () => {
+        let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
+        let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
+        ws.fromProject(project);
+        ws.isModified().should.be.true;
+        let request = ws.toSetWorkspaceRequests();
+        request.workspace.langauge.should.be.equal("csharp");
+    });
+
+    it("is retains the language of hte project", async () => {
+        let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
+        let project = await createProject({ packageName: "console", language: "fsharp", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
+        ws.fromProject(project);
+        ws.isModified().should.be.true;
+        let request = ws.toSetWorkspaceRequests();
+        request.workspace.langauge.should.be.equal("fsharp");
+    });
+
     it("is marked as modified when a document is opened", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
-        let project = await createProject("console", [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }]);
+        let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
         ws.fromProject(project);
         await ws.openDocument({ fileName: "program.cs" });
         ws.isModified().should.be.true;
@@ -34,7 +52,7 @@ describe("a workspace", () => {
 
     it("is not marked as modified when is exported as setWorkspaceRequest object", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
-        let project = await createProject("console", [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }]);
+        let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
         ws.fromProject(project);
         ws.isModified().should.be.true;
         ws.toSetWorkspaceRequests();
@@ -43,7 +61,7 @@ describe("a workspace", () => {
 
     it("is not marked as modified when a document is opened again", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
-        let project = await createProject("console", [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }]);
+        let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
         ws.fromProject(project);
         ws.isModified().should.be.true;
         let doc = await ws.openDocument({ fileName: "program.cs" });
@@ -54,7 +72,7 @@ describe("a workspace", () => {
 
     it("is marked as modified when a document is opened and  the content is changed", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
-        let project = await createProject("console", [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }]);
+        let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
         ws.fromProject(project);
         let doc = await ws.openDocument({ fileName: "program.cs" });
         doc.setContent("modified content");
@@ -63,7 +81,7 @@ describe("a workspace", () => {
 
     it("generates set workspace request object", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
-        let project = await createProject("console", [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }]);
+        let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "the program" }, { name: "otherFile.cs", content: "other file content" }] });
         ws.fromProject(project);
         let doc = await ws.openDocument({ fileName: "program.cs" });
         doc.setContent("modified content");
@@ -76,11 +94,14 @@ describe("a workspace", () => {
     it("generates set workspace request object with active bufferId equal to the document currently open in an editor", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
         let project = await createProject(
-            "console",
-            [
-                { name: "program.cs", content: "the program" },
-                { name: "otherFile.cs", content: "other file content" }
-            ]);
+            {
+                packageName: "console",
+                files:
+                    [
+                        { name: "program.cs", content: "the program" },
+                        { name: "otherFile.cs", content: "other file content" }
+                    ]
+            });
 
         ws.fromProject(project);
         let editorZero = new FakeMonacoTextEditor("0");
@@ -100,11 +121,13 @@ describe("a workspace", () => {
     it("can open a document and set its content", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
         let project = await createProject(
-            "console",
-            [
-                { name: "program.cs", content: "the program" },
-                { name: "otherFile.cs", content: "other file content" }
-            ]);
+            {
+                packageName: "console",
+                files: [
+                    { name: "program.cs", content: "the program" },
+                    { name: "otherFile.cs", content: "other file content" }
+                ]
+            });
 
         ws.fromProject(project);
         let doc = await ws.openDocument({ fileName: "program.cs", content: "content override" });
@@ -115,11 +138,13 @@ describe("a workspace", () => {
     it("can open a document in the editor and set its content", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
         let project = await createProject(
-            "console",
-            [
-                { name: "program.cs", content: "the program" },
-                { name: "otherFile.cs", content: "other file content" }
-            ]);
+            {
+                packageName: "console",
+                files: [
+                    { name: "program.cs", content: "the program" },
+                    { name: "otherFile.cs", content: "other file content" }
+                ]
+            });
 
         let editorZero = new FakeMonacoTextEditor("0");
         ws.fromProject(project);
@@ -134,11 +159,13 @@ describe("a workspace", () => {
     it("can open a document in one edtior at a time", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
         let project = await createProject(
-            "console",
-            [
-                { name: "program.cs", content: "the program" },
-                { name: "otherFile.cs", content: "other file content" }
-            ]);
+            {
+                packageName: "console",
+                files: [
+                    { name: "program.cs", content: "the program" },
+                    { name: "otherFile.cs", content: "other file content" }
+                ]
+            });
 
         ws.fromProject(project);
         let editorZero = new FakeMonacoTextEditor("0");
@@ -158,11 +185,13 @@ describe("a workspace", () => {
     it("can open documents in different edtiors at same time", async () => {
         let ws = new Workspace(new FakeMessageBus("0"), new FakeIdGenerator());
         let project = await createProject(
-            "console",
-            [
-                { name: "program.cs", content: "the program" },
-                { name: "otherFile.cs", content: "other file content" }
-            ]);
+            {
+                packageName: "console",
+                files: [
+                    { name: "program.cs", content: "the program" },
+                    { name: "otherFile.cs", content: "other file content" }
+                ]
+            });
 
         ws.fromProject(project);
         let editorZero = new FakeMonacoTextEditor("0");

--- a/Microsoft.DotNet.Try.js/test/session.compileapi.specs.ts
+++ b/Microsoft.DotNet.Try.js/test/session.compileapi.specs.ts
@@ -38,7 +38,7 @@ describe("a user", () => {
 
             registerForRequestIdGeneration(configuration, editorIFrame, dom.window, (_rid) => "TestRun");
 
-            let project = await createProject("console", [{ name: "program.cs", content: "" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "" }] });
             session.openProject(project);
 
             let result = await session.compile();

--- a/Microsoft.DotNet.Try.js/test/session.documentapi.specs.ts
+++ b/Microsoft.DotNet.Try.js/test/session.documentapi.specs.ts
@@ -32,7 +32,7 @@ describe("A user", () => {
     describe("with a trydotnet session", () => {
         it("can open a document", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "file content" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "file content" }] });
             await session.openProject(project);
             let document = await session.openDocument({ fileName: "program.cs" });
 
@@ -42,7 +42,7 @@ describe("A user", () => {
 
         it("creates a empty document when the project does not have a matching file", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "file content" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "file content" }] });
             await session.openProject(project);
 
             let document = await session.openDocument({ fileName: "program_two.cs" });
@@ -53,7 +53,7 @@ describe("A user", () => {
 
         it("creates a empty document when using region and the project does not have a matching file", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "file content" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "file content" }] });
             await session.openProject(project);
 
             let document = await session.openDocument({ fileName: "program_two.cs", region: "controller" });
@@ -64,7 +64,7 @@ describe("A user", () => {
 
         it("can open a document with region as identifier", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "//pre\n#region controller\n//content\n e#endregion\n//post/n" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "//pre\n#region controller\n//content\n e#endregion\n//post/n" }] });
             await session.openProject(project);
 
             registerForRequestIdGeneration(configuration, editorIFrame, dom.window, (_rid) => "TestRun");
@@ -83,7 +83,7 @@ describe("A user", () => {
             let editorState = { content: "", documentId: "" };
             let session = await createReadySession(configuration, editorIFrame, dom.window);
             let defaultEditor = session.getTextEditor();
-            let project = await createProject("console", [{ name: "program.cs", content: "file content" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "file content" }] });
             registerForRequestIdGeneration(configuration, editorIFrame, dom.window, _r => "TestRun0");
             await session.openProject(project);
             registerForEditorMessages(configuration, editorIFrame, dom.window, editorState);
@@ -99,7 +99,7 @@ describe("A user", () => {
                 let editorState = { content: "", documentId: "" };
                 let session = await createReadySession(configuration, editorIFrame, dom.window);
                 let defaultEditor = session.getTextEditor();
-                let project = await createProject("console", [{ name: "program.cs", content: "file content" }]);
+                let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "file content" }] });
                 await session.openProject(project);
                 registerForRequestIdGeneration(configuration, editorIFrame, dom.window, _r => "TestRun1");
 
@@ -116,7 +116,7 @@ describe("A user", () => {
                 let editorState = { content: "", documentId: "" };
                 let session = await createReadySession(configuration, editorIFrame, dom.window);
                 let defaultEditor = session.getTextEditor();
-                let project = await createProject("console", [{ name: "program.cs", content: "file content" }]);
+                let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "file content" }] });
                 await session.openProject(project);
                 registerForRequestIdGeneration(configuration, editorIFrame, dom.window, _r => "TestRun2");
                 registerForEditorMessages(configuration, editorIFrame, dom.window, editorState);
@@ -135,11 +135,12 @@ describe("A user", () => {
                 let session = await createReadySessionWithMultipleEditors(configuration, editorIFrames, dom.window);
 
                 let project = await createProject(
-                    "console",
-                    [
-                        { name: "program.cs", content: "the program" },
-                        { name: "otherFile.cs", content: "other file content" }
-                    ]);
+                    {
+                        packageName: "console", files: [
+                            { name: "program.cs", content: "the program" },
+                            { name: "otherFile.cs", content: "other file content" }
+                        ]
+                    });
 
                 await session.openProject(project);
 
@@ -171,11 +172,12 @@ describe("A user", () => {
                 let session = await createReadySessionWithMultipleEditors(configuration, editorIFrames, dom.window);
 
                 let project = await createProject(
-                    "console",
-                    [
-                        { name: "program.cs", content: "the program" },
-                        { name: "otherFile.cs", content: "other file content" }
-                    ]);
+                    {
+                        packageName: "console", files: [
+                            { name: "program.cs", content: "the program" },
+                            { name: "otherFile.cs", content: "other file content" }
+                        ]
+                    });
 
                 await session.openProject(project);
 

--- a/Microsoft.DotNet.Try.js/test/session.intellisense.specs.ts
+++ b/Microsoft.DotNet.Try.js/test/session.intellisense.specs.ts
@@ -22,7 +22,7 @@ describe.skip("a user", () => {
     describe("with a trydotnet session", () => {
         it("can request completion list", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "Console.W" }])
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "Console.W" }] })
             session.openProject(project);
             let completionListResult = await session.getCompletionList("program.cs", 9);
             completionListResult.should.not.be.null;
@@ -30,7 +30,7 @@ describe.skip("a user", () => {
 
         it("can request completion list with a scope", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "var a = 10; #region controller Console.W #endregion" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "var a = 10; #region controller Console.W #endregion" }] });
             session.openProject(project);
             let completionListResult = await session.getCompletionList("program.cs", 9, "controller");
             completionListResult.should.not.be.null;
@@ -38,7 +38,7 @@ describe.skip("a user", () => {
 
         it("can request signature help", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "Console.Write()" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "Console.Write()" }] });
             session.openProject(project);
 
             let singatureHelpResult = await session.getSignatureHelp("program.cs", 14);
@@ -47,7 +47,7 @@ describe.skip("a user", () => {
 
         it("can request signature help with a scope", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "var a = 10; #region controller Console.Write() #endregion" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "var a = 10; #region controller Console.Write() #endregion" }] });
             session.openProject(project);
 
             let singatureHelpResult = await session.getSignatureHelp("program.cs", 14, "controller");

--- a/Microsoft.DotNet.Try.js/test/session.projectapi.specs.ts
+++ b/Microsoft.DotNet.Try.js/test/session.projectapi.specs.ts
@@ -22,7 +22,7 @@ describe("a user", () => {
     describe("with a trydotnet session", () => {
         it("can open a project", async () => {
             let session = await createReadySession(configuration, editorIFrame, dom.window);
-            let project = await createProject("console", [{ name: "program.cs", content: "" }]);
+            let project = await createProject({ packageName: "console", files: [{ name: "program.cs", content: "" }] });
             await session.openProject(project);
         });
     });

--- a/WorkspaceServer/Models/Execution/WorkspaceExtensions.cs
+++ b/WorkspaceServer/Models/Execution/WorkspaceExtensions.cs
@@ -56,6 +56,7 @@ namespace WorkspaceServer.Models.Execution
                 workspace.Files,
                 workspace.Buffers.Concat(new[] { new Buffer(BufferId.Parse(id), text) }).ToArray(),
                 workspace.WorkspaceType,
+                workspace.Language,
                 workspace.IncludeInstrumentation);
 
         public static Workspace RemoveBuffer(
@@ -66,6 +67,7 @@ namespace WorkspaceServer.Models.Execution
                 workspace.Files,
                 workspace.Buffers.Where(b => b.Id.ToString() != id).ToArray(),
                 workspace.WorkspaceType,
+                workspace.Language,
                 workspace.IncludeInstrumentation);
 
         public static Workspace ReplaceBuffer(
@@ -85,6 +87,7 @@ namespace WorkspaceServer.Models.Execution
                          .ToArray(),
                 workspace.Buffers,
                 workspace.WorkspaceType,
+                workspace.Language,
                 workspace.IncludeInstrumentation);
 
         public static Workspace ReplaceFile(
@@ -99,6 +102,7 @@ namespace WorkspaceServer.Models.Execution
                          .ToArray(),
                 workspace.Buffers,
                 workspace.WorkspaceType,
+                workspace.Language,
                 workspace.IncludeInstrumentation);
 
     }

--- a/WorkspaceServer/UriOrFileInfo.cs
+++ b/WorkspaceServer/UriOrFileInfo.cs
@@ -6,12 +6,15 @@ using System.IO;
 
 namespace WorkspaceServer
 {
-    public class PackageSource
+    public class UriOrFileInfo
     {
-        readonly DirectoryInfo _directory;
+        readonly FileInfo _fileInfo;
         readonly Uri _uri;
+        public bool IsFile { get; }
 
-        public PackageSource(string value)
+        public string FileExtension { get; }
+
+        public UriOrFileInfo(string value)
         {
             if (value == null)
             {
@@ -20,21 +23,26 @@ namespace WorkspaceServer
 
             // Uri.IsWellFormed will return false for path-like strings:
             // (https://docs.microsoft.com/en-us/dotnet/api/system.uri.iswellformeduristring?view=netcore-2.2)
-            if (Uri.IsWellFormedUriString(value, UriKind.Absolute) && 
+            if (Uri.IsWellFormedUriString(value, UriKind.Absolute) &&
                 Uri.TryCreate(value, UriKind.Absolute, out var uri)
                 && uri?.Scheme != null)
             {
                 _uri = uri;
+                IsFile = false;
             }
             else
             {
-                _directory = new DirectoryInfo(value);
+                _fileInfo = new FileInfo(value);
+                IsFile = true;
+                FileExtension = _fileInfo.Extension;
             }
         }
 
+     
+
         public override string ToString()
         {
-            return _directory?.ToString() ?? _uri.ToString();
+            return _fileInfo?.ToString() ?? _uri.ToString();
         }
     }
 }


### PR DESCRIPTION
language detected in markdown fences is the pushed to html and the js api makes it flow as part of the protocol back into agent.

dotnet try verify detects incompatibility between project and language