### PR TITLE
ensure failing build/test exits early

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -13,6 +13,9 @@ function TestUsingNPM([string] $testPath) {
 try {
     # invoke regular build/test script
     . (Join-Path $PSScriptRoot "common\build.ps1") @args
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
 
     # directly invoke npm tests
     if (($null -ne $args) -and ($args.Contains("-test") -or $args.Contains("-t"))) {


### PR DESCRIPTION
When dot-sourcing another `.ps1` script the value of `$LASTEXITCODE` must be checked and handled.