### PR TITLE
update System.CommandLine

### DIFF
--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -126,14 +126,14 @@ namespace MLS.Agent.CommandLine
                 var command = new RootCommand
                 {
                     Name = "dotnet-try",
-                    Description = ".NET interactive documentation in your browser",
-                    Argument = new Argument<DirectoryInfo>
-                    {
-                        Arity = ArgumentArity.ZeroOrOne,
-                        Name = nameof(StartupOptions.Dir).ToLower(),
-                        Description = "Specify the path to the root directory for your documentation"
-                    }.ExistingOnly()
+                    Description = ".NET interactive documentation in your browser"
                 };
+                command.AddArgument(new Argument<DirectoryInfo>
+                {
+                    Arity = ArgumentArity.ZeroOrOne,
+                    Name = nameof(StartupOptions.Dir).ToLower(),
+                    Description = "Specify the path to the root directory for your documentation"
+                }.ExistingOnly());
 
                 command.AddOption(new Option(
                                       "--add-package-source",
@@ -301,13 +301,15 @@ namespace MLS.Agent.CommandLine
 
             Command Jupyter()
             {
-                var jupyterCommand = new Command("jupyter", "Starts dotnet try as a Jupyter kernel");
-                jupyterCommand.IsHidden = true;
+                var jupyterCommand = new Command("jupyter", "Starts dotnet try as a Jupyter kernel")
+                {
+                    IsHidden = true
+                };
                 var connectionFileArgument = new Argument<FileInfo>
                 {
                     Name = "ConnectionFile"
                 }.ExistingOnly();
-                jupyterCommand.Argument = connectionFileArgument;
+                jupyterCommand.AddArgument(connectionFileArgument);
 
                 jupyterCommand.Handler = CommandHandler.Create<JupyterOptions, IConsole, InvocationContext>((options, console, context) =>
                 {
@@ -335,8 +337,10 @@ namespace MLS.Agent.CommandLine
             {
                 var packCommand = new Command("pack", "Create a Try .NET package");
                 packCommand.IsHidden = true;
-                packCommand.Argument = new Argument<DirectoryInfo>();
-                packCommand.Argument.Name = nameof(PackOptions.PackTarget);
+                packCommand.AddArgument(new Argument<DirectoryInfo>
+                {
+                    Name = nameof(PackOptions.PackTarget)
+                });
 
                 packCommand.AddOption(new Option("--version",
                                                  "The version of the Try .NET package",
@@ -356,8 +360,10 @@ namespace MLS.Agent.CommandLine
             Command Install()
             {
                 var installCommand = new Command("install", "Install a Try .NET package");
-                installCommand.Argument = new Argument<string>();
-                installCommand.Argument.Name = nameof(InstallOptions.PackageName);
+                installCommand.AddArgument(new Argument<string>
+                {
+                    Name = nameof(InstallOptions.PackageName)
+                });
                 installCommand.IsHidden = true;
 
                 var option = new Option("--add-source",
@@ -372,14 +378,15 @@ namespace MLS.Agent.CommandLine
 
             Command Verify()
             {
-                var verifyCommand = new Command("verify", "Verify Markdown files in the target directory and its children.")
+                var dir = new Argument<DirectoryInfo>(() => new DirectoryInfo(Directory.GetCurrentDirectory()))
                 {
-                    Argument = new Argument<DirectoryInfo>(() => new DirectoryInfo(Directory.GetCurrentDirectory()))
-                    {
-                        Name = nameof(VerifyOptions.Dir).ToLower(),
-                        Description = "Specify the path to the root directory"
-                    }.ExistingOnly()
-                };
+                    Name = nameof(VerifyOptions.Dir).ToLower(),
+                    Description = "Specify the path to the root directory"
+                }.ExistingOnly();
+
+                var verifyCommand = new Command("verify", "Verify Markdown files in the target directory and its children.");
+
+                verifyCommand.AddArgument(dir);
 
                 verifyCommand.Handler = CommandHandler.Create<VerifyOptions, IConsole, StartupOptions>((options, console, startupOptions) =>
                 {

--- a/MLS.Agent/MLS.Agent.csproj
+++ b/MLS.Agent/MLS.Agent.csproj
@@ -86,7 +86,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="system.commandline.experimental" Version="0.2.0-alpha.19261.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
     <PackageReference Include="TaskExtensions" Version="0.1.8580001">
       <PrivateAssets>all</PrivateAssets>
@@ -126,11 +126,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Target Name="BuildCss"
-          Inputs="$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Try.Styles\sass\trydotnet.scss"
-          Outputs="$(MSBuildThisFileDirectory)wwwroot\css\trydotnet.css"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(NCrunch)' != '1'">
+  <Target Name="BuildCss" Inputs="$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Try.Styles\sass\trydotnet.scss" Outputs="$(MSBuildThisFileDirectory)wwwroot\css\trydotnet.css" BeforeTargets="BeforeBuild" Condition="'$(NCrunch)' != '1'">
 
     <PropertyGroup>
       <_TryDotNetCssExists Condition="Exists('$(MSBuildThisFileDirectory)wwwroot\css\trydotnet.css')">true</_TryDotNetCssExists>
@@ -164,12 +160,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="BuildTryDotNetJs"
-          Inputs="@(TryDotNetJsInput)"
-          Outputs="$(TryDotNetJsFile);$(TryDotNetJsMap)"
-          DependsOnTargets="GatherInputs"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(NCrunch)' != '1'">
+  <Target Name="BuildTryDotNetJs" Inputs="@(TryDotNetJsInput)" Outputs="$(TryDotNetJsFile);$(TryDotNetJsMap)" DependsOnTargets="GatherInputs" BeforeTargets="BeforeBuild" Condition="'$(NCrunch)' != '1'">
     <PropertyGroup>
       <_TryDotNetMinJsExists Condition="Exists('$(TryDotNetJsFile)')">true</_TryDotNetMinJsExists>
     </PropertyGroup>
@@ -187,12 +178,7 @@
     </ItemGroup>
   </Target>
   
-  <Target Name="BuildClient"
-          Inputs="@(ClientInputFiles)"
-          Outputs="$(ClientOutputFile)"
-          DependsOnTargets="GatherInputs"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(NCrunch)' != '1'">
+  <Target Name="BuildClient" Inputs="@(ClientInputFiles)" Outputs="$(ClientOutputFile)" DependsOnTargets="GatherInputs" BeforeTargets="BeforeBuild" Condition="'$(NCrunch)' != '1'">
 
     <PropertyGroup>
       <_TryDotNetClientExists Condition="Exists('$(ClientOutputFile)')">true</_TryDotNetClientExists>

--- a/MLS.Agent/MLS.Agent.csproj
+++ b/MLS.Agent/MLS.Agent.csproj
@@ -86,7 +86,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
     <PackageReference Include="TaskExtensions" Version="0.1.8580001">
       <PrivateAssets>all</PrivateAssets>

--- a/MLS.PackageTool/MLS.PackageTool.csproj
+++ b/MLS.PackageTool/MLS.PackageTool.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="system.commandline.experimental" Version="0.2.0-alpha.19261.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
   </ItemGroup>
 
 </Project>

--- a/MLS.PackageTool/MLS.PackageTool.csproj
+++ b/MLS.PackageTool/MLS.PackageTool.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.DotNet.Try.Client/package-lock.json
+++ b/Microsoft.DotNet.Try.Client/package-lock.json
@@ -4560,8 +4560,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4582,14 +4581,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4604,20 +4601,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4734,8 +4728,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4747,7 +4740,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4762,7 +4754,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4770,14 +4761,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4796,7 +4785,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4877,8 +4865,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4890,7 +4877,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4976,8 +4962,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5013,7 +4998,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5033,7 +5017,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5077,14 +5060,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9743,8 +9724,7 @@
           "version": "1.2.0",
           "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/MLS/npm/registry/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
+++ b/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.17.0" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
+++ b/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.17.0" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19261.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/Microsoft.DotNet.Try.ProjectTemplate/Tutorial/content/Microsoft.DotNet.Try.ProjectTemplate.Tutorial.csproj
+++ b/Microsoft.DotNet.Try.ProjectTemplate/Tutorial/content/Microsoft.DotNet.Try.ProjectTemplate.Tutorial.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19226.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19226.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.DotNet.Try.ProjectTemplate/Tutorial/content/Microsoft.DotNet.Try.ProjectTemplate.Tutorial.csproj
+++ b/Microsoft.DotNet.Try.ProjectTemplate/Tutorial/content/Microsoft.DotNet.Try.ProjectTemplate.Tutorial.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.DotNet.Try.js/package-lock.json
+++ b/Microsoft.DotNet.Try.js/package-lock.json
@@ -5700,8 +5700,7 @@
           "version": "1.2.0",
           "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/MLS/npm/registry/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/Samples/Beginners/myapp/myapp.csproj
+++ b/Samples/Beginners/myapp/myapp.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19176.2" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19176.2" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/Beginners/myapp/myapp.csproj
+++ b/Samples/Beginners/myapp/myapp.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/csharp8/ExploreCsharpEight/ExploreCsharpEight.csproj
+++ b/Samples/csharp8/ExploreCsharpEight/ExploreCsharpEight.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19174.3" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/csharp8/ExploreCsharpEight/ExploreCsharpEight.csproj
+++ b/Samples/csharp8/ExploreCsharpEight/ExploreCsharpEight.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
   </ItemGroup>
 
 </Project>

--- a/WasmCodeRunner/CommandLineBuilderExtensions.cs
+++ b/WasmCodeRunner/CommandLineBuilderExtensions.cs
@@ -30,8 +30,6 @@ namespace MLS.WasmCodeRunner
 
             builder.Command.ConfigureFromMethod(method);
 
-
-
             return builder;
         }
 
@@ -64,11 +62,11 @@ namespace MLS.WasmCodeRunner
             if (method.GetParameters()
                 .FirstOrDefault(p => _argumentParameterNames.Contains(p.Name)) is ParameterInfo argsParam)
             {
-                command.Argument = new Argument
+                command.AddArgument(new Argument
                 {
                     ArgumentType = argsParam.ParameterType,
                     Name = argsParam.Name
-                };
+                });
             }
 
             command.Handler = CommandHandler.Create(method);
@@ -89,7 +87,7 @@ namespace MLS.WasmCodeRunner
 
             foreach (var option in descriptor.ParameterDescriptors
                 .Where(d => !omittedTypes.Contains(d.Type))
-                .Where(d => !_argumentParameterNames.Contains(d.Name))
+                .Where(d => !_argumentParameterNames.Contains(d.ValueName))
                 .Select(p => p.BuildOption()))
             {
                 yield return option;
@@ -110,7 +108,7 @@ namespace MLS.WasmCodeRunner
 
             var option = new Option(
                 parameter.BuildAlias(),
-                parameter.Name,
+                parameter.ValueName,
                 argument);
 
             return option;
@@ -123,7 +121,7 @@ namespace MLS.WasmCodeRunner
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            return BuildAlias(descriptor.Name);
+            return BuildAlias(descriptor.ValueName);
         }
 
         internal static string BuildAlias(string parameterName)

--- a/WasmCodeRunner/MLS.WasmCodeRunner.csproj
+++ b/WasmCodeRunner/MLS.WasmCodeRunner.csproj
@@ -8,6 +8,6 @@
   
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
   </ItemGroup>
 </Project>

--- a/WasmCodeRunner/MLS.WasmCodeRunner.csproj
+++ b/WasmCodeRunner/MLS.WasmCodeRunner.csproj
@@ -8,6 +8,6 @@
   
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="system.commandline.experimental" Version="0.2.0-alpha.19261.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
   </ItemGroup>
 </Project>

--- a/WorkspaceServer/DirectoryAccessor.cs
+++ b/WorkspaceServer/DirectoryAccessor.cs
@@ -53,8 +53,10 @@ namespace WorkspaceServer
         public static DirectoryInfo GetFullyQualifiedRoot(this IDirectoryAccessor directoryAccessor) =>
             (DirectoryInfo) directoryAccessor.GetFullyQualifiedPath(new RelativeDirectoryPath("."));
 
-        public static FileInfo GetFullyQualifiedFilePath(this IDirectoryAccessor directoryAccessor, string relativeFilePath) =>
-            (FileInfo) directoryAccessor.GetFullyQualifiedPath(new RelativeFilePath(relativeFilePath));
+        public static FileInfo GetFullyQualifiedFilePath(this IDirectoryAccessor directoryAccessor, string relativeFilePath) => 
+            GetFullyQualifiedFilePath(directoryAccessor, new RelativeFilePath(relativeFilePath));
 
+        public static FileInfo GetFullyQualifiedFilePath(this IDirectoryAccessor directoryAccessor, RelativeFilePath relativePath) => 
+            (FileInfo) directoryAccessor.GetFullyQualifiedPath(relativePath);
     }
 }

--- a/WorkspaceServer/Packaging/BlazorPackageInitializer.cs
+++ b/WorkspaceServer/Packaging/BlazorPackageInitializer.cs
@@ -56,7 +56,7 @@ namespace WorkspaceServer.Packaging
                 await dotnet.AddPackage(packageId);
             }
 
-            await dotnet.AddPackage("System.CommandLine.Experimental", "0.2.0-alpha.19261.1");
+            await dotnet.AddPackage("System.CommandLine.Experimental", "0.3.0-alpha.19306.1");
 
             var result = await dotnet.Build("-o runtime /bl", budget: budget);
             var stuff = string.Concat(string.Join("\n", result.Output), (string.Join("\n", result.Error)));

--- a/WorkspaceServer/Packaging/BlazorPackageInitializer.cs
+++ b/WorkspaceServer/Packaging/BlazorPackageInitializer.cs
@@ -56,7 +56,7 @@ namespace WorkspaceServer.Packaging
                 await dotnet.AddPackage(packageId);
             }
 
-            await dotnet.AddPackage("System.CommandLine.Experimental", "0.3.0-alpha.19306.1");
+            await dotnet.AddPackage("System.CommandLine.Experimental", "0.3.0-alpha.19312.1");
 
             var result = await dotnet.Build("-o runtime /bl", budget: budget);
             var stuff = string.Concat(string.Join("\n", result.Output), (string.Join("\n", result.Error)));

--- a/WorkspaceServer/WorkspaceServer.csproj
+++ b/WorkspaceServer/WorkspaceServer.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.1.0-beta3-final" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="NewtonSoft.Json" Version="11.0.2" />
-    <PackageReference Include="system.commandline.experimental" Version="0.2.0-alpha.19261.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
     <PackageReference Include="Pocket.Disposable" Version="1.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/WorkspaceServer/WorkspaceServer.csproj
+++ b/WorkspaceServer/WorkspaceServer.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.1.0-beta3-final" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="NewtonSoft.Json" Version="11.0.2" />
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
     <PackageReference Include="Pocket.Disposable" Version="1.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/docs/GettingStarted/Snippets/Snippets.csproj
+++ b/docs/GettingStarted/Snippets/Snippets.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19261.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19261.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
   </ItemGroup>
 
 </Project>

--- a/docs/GettingStarted/Snippets/Snippets.csproj
+++ b/docs/GettingStarted/Snippets/Snippets.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19306.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19306.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This brings in minor updates to the command line parser. 

Updated help looks like this. Thoughts?

```console
> dotnet try -h
dotnet-try:
  Interactive documentation in your browser

Usage:
  dotnet-try [options] [<dir>] [command]

Arguments:
  <dir>    Specify the path to the root directory for your documentation

Options:
  --add-package-source <NuGet source>    Specify an additional NuGet package source
  --package <name or .csproj>            Specify a Try .NET package or path to a .csproj to run code samples with
  --package-version <version>            Specify a Try .NET package version to use with the --package option
  --uri <uri>                            Specify a URL or a relative path to a Markdown file
  --enable-preview-features              Enable preview features
  --log-path <dir>                       Enable file logging to the specified directory
  --verbose                              Enable verbose logging to the console
  --port <port>                          Specify the port for dotnet try to listen on
  --version                              Display version information

Commands:
  demo            Learn how to create Try .NET content with an interactive demo
  verify <dir>    Verify Markdown files in the target directory and its children.

> dotnet try verify -h
verify:
  Verify Markdown files in the target directory and its children.

Usage:
  dotnet-try [<dir>] verify [<dir>]

Arguments:
  <dir>    Specify the path to the root directory for your documentation
```



