### PR TITLE
ensure aspnet.webapi package exists

### DIFF
--- a/WorkspaceServer.Tests/AspNetWorkspaceTests.cs
+++ b/WorkspaceServer.Tests/AspNetWorkspaceTests.cs
@@ -38,7 +38,8 @@ namespace WorkspaceServer.Tests
         {
             var registry = Default.PackageFinder;
             var server = new RoslynWorkspaceServer(registry);
-            var package = await registry.Get<IHaveADirectory>("aspnet.webapi");
+            var package = await registry.Get<Package>("aspnet.webapi");
+            await package.CreateRoslynWorkspaceAsync(new Budget()); // ensure the package exists on disk
 
             var workspace = WorkspaceFactory.CreateWorkspaceFromDirectory(package.Directory, "aspnet.webapi");
 


### PR DESCRIPTION
When debugging I found a test that expects a package to exist on disk and this might not be the case if:

1. You recently deleted the `%USERPROFILE%\.trydotnet\packages` directory.
2. The `%TRYDOTNET_PACKAGES_PATH%` directory is empty or doesn't exist.

Flaky CI and PR builds have partly been caused by (2) above because official builds set the `%TRYDOTNET_PACKAGES_PATH%` variable to be under `artifacts/` to ensure it's always clean for the given test run, and it's possible for the affected test to run either before _or_ after another test that created the package.