### PR TITLE
ensure sdk 2.1.503 is installed for all builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,8 @@ variables:
     value: .NETCore
   - name: BlazorTemplateVersion
     value: 0.7.0
+  - name: DotNetSdkVersion
+    value: 2.1.503
   - name: TryDotNetPackagesPath
     value: $(Build.SourcesDirectory)/artifacts/.trydotnet/packages
 
@@ -67,6 +69,13 @@ jobs:
         displayName: Add NodeJS/npm
         inputs:
           versionSpec: '>=11'
+
+      - task: UseDotNet@2
+        displayName: Add dotnet
+        inputs:
+          packageType: sdk
+          version: $(DotNetSdkVersion)
+          installationPath: $(Agent.ToolsDirectory)\dotnet
 
       - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
         displayName: Install Blazor templates
@@ -142,7 +151,7 @@ jobs:
         displayName: Add dotnet
         inputs:
           packageType: sdk
-          version: 2.1.503
+          version: $(DotNetSdkVersion)
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
       - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)


### PR DESCRIPTION
Some internal signed builds were failing claiming that the `blazor` template was not installed.  Examining the logs showed that those failing builds were installing the templates using SDK version 2.1.507, but everything else in this build uses 2.1.503.  The Linux leg already had this step, but it was missing from Windows.