### PR TITLE
Use the project asset only if the command line succeeded

### DIFF
--- a/WorkspaceServer/Packaging/ToolPackageLocator.cs
+++ b/WorkspaceServer/Packaging/ToolPackageLocator.cs
@@ -43,13 +43,7 @@ namespace WorkspaceServer.Packaging
         public async Task<DirectoryInfo> PrepareToolAndLocateAssetDirectory(PackageTool tool)
         {
             await tool.Prepare();
-            var projectAsset = await tool.LocateProjectAsset();
-            if (projectAsset != null)
-            {
-                return projectAsset.DirectoryAccessor.GetFullyQualifiedRoot();
-            }
-
-            return null;
+            return (await tool.LocateProjectAsset()).DirectoryAccessor.GetFullyQualifiedRoot();
         }
     }
 }

--- a/WorkspaceServer/Packaging/ToolPackageLocator.cs
+++ b/WorkspaceServer/Packaging/ToolPackageLocator.cs
@@ -43,7 +43,13 @@ namespace WorkspaceServer.Packaging
         public async Task<DirectoryInfo> PrepareToolAndLocateAssetDirectory(PackageTool tool)
         {
             await tool.Prepare();
-            return (await tool.LocateProjectAsset()).DirectoryAccessor.GetFullyQualifiedRoot();
+            var projectAsset = await tool.LocateProjectAsset();
+            if (projectAsset != null)
+            {
+                return projectAsset.DirectoryAccessor.GetFullyQualifiedRoot();
+            }
+
+            return null;
         }
     }
 }

--- a/WorkspaceServer/Packaging/WebAssemblyAssetFinder.cs
+++ b/WorkspaceServer/Packaging/WebAssemblyAssetFinder.cs
@@ -38,22 +38,27 @@ namespace WorkspaceServer.Packaging
         protected async Task<IPackage> CreatePackage(PackageDescriptor descriptor, PackageTool tool)
         {
             await tool.Prepare();
-            var projectAsset = await tool.LocateProjectAsset();
-            if (projectAsset != null)
+            try
             {
+                var projectAsset = await tool.LocateProjectAsset();
                 var package = new Package2(descriptor.Name, tool.DirectoryAccessor);
                 package.Add(projectAsset);
-
-                var wasmAsset = await tool.LocateWasmAsset();
-                if (wasmAsset != null)
+                try
                 {
+                    var wasmAsset = await tool.LocateWasmAsset();
                     package.Add(wasmAsset);
-                    return package;
                 }
+                catch (WasmAssetNotFoundException)
+                {
+
+                }
+               
+                return package;
             }
-
-            return null;
+            catch (ProjectAssetNotFoundException)
+            {
+                return null;
+            }
         }
-
     }
 }

--- a/WorkspaceServer/WorkspaceFeatures/PackageTool.cs
+++ b/WorkspaceServer/WorkspaceFeatures/PackageTool.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using MLS.Agent.Tools;
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -44,7 +45,7 @@ namespace WorkspaceServer.WorkspaceFeatures
                 return new ProjectAsset(new FileSystemDirectoryAccessor(projectDirectory));
             }
 
-            return null;
+            throw new ProjectAssetNotFoundException($"Could not locate project asset for tool: {Name}");
         }
 
         private async Task<DirectoryInfo> GetProjectDirectory(string command)
@@ -74,7 +75,7 @@ namespace WorkspaceServer.WorkspaceFeatures
                 return new WebAssemblyAsset(new FileSystemDirectoryAccessor(projectDirectory));
             }
 
-            return null;
+            throw new WasmAssetNotFoundException($"Could not locate wasm asset for tool: {Name}");
         }
 
         public Task Prepare()
@@ -85,6 +86,20 @@ namespace WorkspaceServer.WorkspaceFeatures
         public bool Exists()
         {
             return DirectoryAccessor.FileExists(Name.ExecutableName());
+        }
+    }
+
+    public class ProjectAssetNotFoundException : Exception
+    {
+        public ProjectAssetNotFoundException(string message): base(message)
+        {
+        }
+    }
+
+    public class WasmAssetNotFoundException : Exception
+    {
+        public WasmAssetNotFoundException(string message) : base(message)
+        {
         }
     }
 }


### PR DESCRIPTION
We should check if the command line execution succeeded before we try to use the output from the results