### PR TITLE
read only region with round-trip emits replace injection point

### DIFF
--- a/MLS.Agent/Markdown/LocalCodeBlockAnnotations.cs
+++ b/MLS.Agent/Markdown/LocalCodeBlockAnnotations.cs
@@ -150,6 +150,16 @@ namespace MLS.Agent.Markdown
                     fileName);
             }
 
+            if (ReadOnlyRegionRoundtrip())
+            {
+                block.AddAttribute("data-trydotnet-injection-point", "replace");
+            }
+
+            bool ReadOnlyRegionRoundtrip()
+            {
+                return !Editable && !string.IsNullOrWhiteSpace(Region) && SourceFile != null && (DestinationFile == null || SourceFile.Equals(DestinationFile));
+            }
+
             await base.AddAttributes(block);
         }
 

--- a/Microsoft.DotNet.Try.Protocol/BufferId.cs
+++ b/Microsoft.DotNet.Try.Protocol/BufferId.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.Try.Protocol
     [JsonConverter(typeof(BufferIdConverter))]
     public class BufferId
     {
+        private const string ReplaceInjectionModifier = "[replace]";
         private const string BeforeInjectionModifier = "[before]";
         private const string AfterInjectionModifier = "[after]";
 
@@ -68,7 +69,10 @@ namespace Microsoft.DotNet.Try.Protocol
         {
             return string.IsNullOrWhiteSpace(regionName)
                 ? regionName
-                : regionName.Replace(BeforeInjectionModifier, string.Empty).Replace(AfterInjectionModifier, string.Empty);
+                : regionName
+                    .Replace(ReplaceInjectionModifier, string.Empty)
+                    .Replace(BeforeInjectionModifier, string.Empty)
+                    .Replace(AfterInjectionModifier, string.Empty);
         }
         public BufferId GetNormalized()
         {


### PR DESCRIPTION
This is a fix for the #263.
Readonly region must be able to perform round trip via replace injection modifier