### PR TITLE
update System.CommandLine to 0.3.0-alpha.19315.2

### DIFF
--- a/MLS.Agent.Tests/ApiContracts/ApiOutputContractTests.cs
+++ b/MLS.Agent.Tests/ApiContracts/ApiOutputContractTests.cs
@@ -9,7 +9,6 @@ using Microsoft.DotNet.Try.Project;
 using Microsoft.DotNet.Try.Protocol;
 using Microsoft.DotNet.Try.Protocol.Tests;
 using Recipes;
-using WorkspaceServer.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,15 +26,9 @@ namespace MLS.Agent.Tests.ApiContracts
             configuration = configuration.SetInteractive(true);
         }
 
-        private async Task EnsureConsoleWorkspaceCreated()
-        {
-            await Default.PackageRegistry.ValueAsync();
-        }
-
         [Fact]
         public async Task The_Run_contract_for_compiling_code_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var viewport = ViewportCode();
 
             var requestJson = new WorkspaceRequest(
@@ -59,7 +52,6 @@ namespace MLS.Agent.Tests.ApiContracts
         [Fact]
         public async Task The_Run_contract_for_noncompiling_code_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var viewport = ViewportCode("doesn't compile");
 
             var request = new WorkspaceRequest(
@@ -85,7 +77,6 @@ namespace MLS.Agent.Tests.ApiContracts
         [Fact]
         public async Task The_Compile_contract_for_compiling_code_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var viewport = ViewportCode();
 
             var requestJson = new WorkspaceRequest(
@@ -120,7 +111,6 @@ namespace MLS.Agent.Tests.ApiContracts
         [Fact]
         public async Task The_Compile_contract_for_noncompiling_code_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var viewport = ViewportCode("doesn't compile");
 
             var request = new WorkspaceRequest(
@@ -146,7 +136,6 @@ namespace MLS.Agent.Tests.ApiContracts
         [Fact]
         public async Task The_Completions_contract_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var viewport = ViewportCode("Console.Ou$$");
 
             var requestJson = new WorkspaceRequest(
@@ -170,7 +159,6 @@ namespace MLS.Agent.Tests.ApiContracts
         [Fact]
         public async Task The_signature_help_contract_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var viewport = ViewportCode("Console.Write($$);");
 
             var requestJson = new WorkspaceRequest(
@@ -194,7 +182,6 @@ namespace MLS.Agent.Tests.ApiContracts
         [Fact(Skip = "Needs moved onto Package2")]
         public async Task The_instrumentation_contract_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var requestJson = new WorkspaceRequest(
                 new Workspace(
                     workspaceType: "console",
@@ -216,7 +203,6 @@ namespace MLS.Agent.Tests.ApiContracts
         [Fact]
         public async Task The_run_contract_with_no_instrumentation_has_not_been_broken()
         {
-            await EnsureConsoleWorkspaceCreated();
             var requestJson = new WorkspaceRequest(
                 new Workspace(
                     workspaceType: "console",

--- a/MLS.Agent.Tests/ApiViaHttpTestsBase.cs
+++ b/MLS.Agent.Tests/ApiViaHttpTestsBase.cs
@@ -20,6 +20,12 @@ namespace MLS.Agent.Tests
         {
             _disposables.Add(output.SubscribeToPocketLogger());
             _disposables.Add(VirtualClock.Start());
+            EnsureConsoleWorkspaceCreated();
+        }
+
+        private void EnsureConsoleWorkspaceCreated()
+        {
+            Task.Run(() => WorkspaceServer.Tests.Default.PackageRegistry.ValueAsync()).Wait();
         }
 
         public void Dispose() => _disposables.Dispose();

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -128,7 +128,6 @@ namespace MLS.Agent.CommandLine
                    })
                    .Build();
 
-
             RootCommand StartInTryMode()
             {
                 var command = new RootCommand
@@ -136,55 +135,69 @@ namespace MLS.Agent.CommandLine
                     Name = "dotnet-try",
                     Description = "Interactive documentation in your browser"
                 };
-                
+
                 command.AddArgument(dirArgument);
 
                 command.AddOption(new Option(
                                       "--add-package-source",
-                                      "Specify an additional NuGet package source",
-                                      new Argument<PackageSource>(new PackageSource(Directory.GetCurrentDirectory()))
+                                      "Specify an additional NuGet package source")
+                                  {
+                                      Argument = new Argument<PackageSource>(() => new PackageSource(Directory.GetCurrentDirectory()))
                                       {
                                           Name = "NuGet source"
-                                      }));
+                                      }
+                                  });
 
                 command.AddOption(new Option(
                                       "--package",
-                                      "Specify a Try .NET package or path to a .csproj to run code samples with",
-                                      new Argument<string>
+                                      "Specify a Try .NET package or path to a .csproj to run code samples with")
+                                  {
+                                      Argument = new Argument<string>
                                       {
                                           Name = "name or .csproj"
-                                      }));
+                                      }
+                                  });
 
                 command.AddOption(new Option(
                                       "--package-version",
-                                      "Specify a Try .NET package version to use with the --package option",
-                                      new Argument<string>
+                                      "Specify a Try .NET package version to use with the --package option")
+                                  {
+                                      Argument = new Argument<string>
                                       {
                                           Name = "version"
-                                      }));
+                                      }
+                                  });
 
                 command.AddOption(new Option(
                                       "--uri",
-                                      "Specify a URL or a relative path to a Markdown file",
-                                      new Argument<Uri>()));
+                                      "Specify a URL or a relative path to a Markdown file")
+                                  {
+                                      Argument = new Argument<Uri>()
+                                  });
 
                 command.AddOption(new Option(
-                                      "--enable-preview-features",
-                                      "Enable preview features",
-                                      new Argument<bool>()));
+                                          "--enable-preview-features",
+                                          "Enable preview features")
+                                  {
+                                      Argument = new Argument<bool>()
+                                  });
 
                 command.AddOption(new Option(
                                       "--log-path",
-                                      "Enable file logging to the specified directory",
-                                      new Argument<DirectoryInfo>
+                                      "Enable file logging to the specified directory")
+                                  {
+                                      Argument = new Argument<DirectoryInfo>
                                       {
                                           Name = "dir"
-                                      }));
+                                      }
+                                  });
 
                 command.AddOption(new Option(
-                                      "--verbose",
-                                      "Enable verbose logging to the console",
-                                      new Argument<bool>()));
+                                          "--verbose",
+                                          "Enable verbose logging to the console")
+                                  {
+                                      Argument = new Argument<bool>()
+                                  });
 
                 var portArgument = new Argument<ushort>();
 
@@ -202,8 +215,10 @@ namespace MLS.Agent.CommandLine
 
                 command.AddOption(new Option(
                                         "--port",
-                                        "Specify the port for dotnet try to listen on",
-                                        portArgument));
+                                        "Specify the port for dotnet try to listen on")
+                                  {
+                                      Argument = portArgument
+                                  });
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {
@@ -221,38 +236,61 @@ namespace MLS.Agent.CommandLine
             {
                 var command = new Command("hosted")
                 {
-                    Description = "Starts the Try .NET agent",
-                    IsHidden = true
+                    new Option(
+                        "--id",
+                        "A unique id for the agent instance (e.g. its development environment id).")
+                    {
+                        Argument = new Argument<string>(defaultValue: () => Environment.MachineName)
+                    },
+                    new Option(
+                        "--production",
+                        "Specifies whether the agent is being run using production resources")
+                    {
+                        Argument = new Argument<bool>()
+                    },
+                    new Option(
+                        "--language-service",
+                        "Specifies whether the agent is being run in language service-only mode")
+                    {
+                        Argument = new Argument<bool>()
+                    },
+                    new Option(
+                        new[]
+                        {
+                            "-k",
+                            "--key"
+                        },
+                        "The encryption key")
+                    {
+                        Argument = new Argument<string>()
+                    },
+                    new Option(
+                        new[]
+                        {
+                            "--ai-key",
+                            "--application-insights-key"
+                        },
+                        "Application Insights key.")
+                    {
+                        Argument = new Argument<string>()
+                    },
+                    new Option(
+                        "--region-id",
+                        "A unique id for the agent region")
+                    {
+                        Argument = new Argument<string>()
+                    },
+                    new Option(
+                        "--log-to-file",
+                        "Writes a log file")
+                    {
+                        Argument = new Argument<bool>()
+                    }
                 };
 
-                command.AddOption(new Option(
-                                      "--id",
-                                      "A unique id for the agent instance (e.g. its development environment id).",
-                                      new Argument<string>(defaultValue: () => Environment.MachineName)));
-                command.AddOption(new Option(
-                                      "--production",
-                                      "Specifies whether the agent is being run using production resources",
-                                      new Argument<bool>()));
-                command.AddOption(new Option(
-                                      "--language-service",
-                                      "Specifies whether the agent is being run in language service-only mode",
-                                      new Argument<bool>()));
-                command.AddOption(new Option(
-                                      new[] { "-k", "--key" },
-                                      "The encryption key",
-                                      new Argument<string>()));
-                command.AddOption(new Option(
-                                      new[] { "--ai-key", "--application-insights-key" },
-                                      "Application Insights key.",
-                                      new Argument<string>()));
-                command.AddOption(new Option(
-                                      "--region-id",
-                                      "A unique id for the agent region",
-                                      new Argument<string>()));
-                command.AddOption(new Option(
-                                      "--log-to-file",
-                                      "Writes a log file",
-                                      new Argument<bool>()));
+                command.Description = "Starts the Try .NET agent";
+
+                command.IsHidden = true;
 
                 command.Handler = CommandHandler.Create<InvocationContext, StartupOptions>((context, options) =>
                 {
@@ -289,13 +327,18 @@ namespace MLS.Agent.CommandLine
 
             Command GitHub()
             {
-                var argument = new Argument<string>();
+                var argument = new Argument<string>
+                {
+                    // System.CommandLine parameter binding does lookup by name,
+                    // so name the argument after the github command's string param
+                    Name = nameof(TryGitHubOptions.Repo)
+                };
 
-                // System.CommandLine parameter binding does lookup by name,
-                // so name the argument after the github command's string param
-                argument.Name = nameof(TryGitHubOptions.Repo);
+                var github = new Command("github", "Try a GitHub repo")
+                {
+                    argument
+                };
 
-                var github = new Command("github", "Try a GitHub repo", argument: argument);
                 github.IsHidden = true;
 
                 github.Handler = CommandHandler.Create<TryGitHubOptions, IConsole>((repo, console) => tryGithub(repo, console));
@@ -339,18 +382,20 @@ namespace MLS.Agent.CommandLine
 
             Command Pack()
             {
-                var packCommand = new Command("pack", "Create a Try .NET package");
-                packCommand.IsHidden = true;
-                packCommand.AddArgument(new Argument<DirectoryInfo>
+                var packCommand = new Command("pack", "Create a Try .NET package")
                 {
-                    Name = nameof(PackOptions.PackTarget)
-                });
+                    new Argument<DirectoryInfo>
+                    {
+                        Name = nameof(PackOptions.PackTarget)
+                    },
+                    new Option("--version", "The version of the Try .NET package")
+                    {
+                        Argument = new Argument<string>()
+                    },
+                    new Option("--enable-wasm", "Enables web assembly code execution")
+                };
 
-                packCommand.AddOption(new Option("--version",
-                                                 "The version of the Try .NET package",
-                                                 new Argument<string>()));
-
-                packCommand.AddOption(new Option("--enable-wasm", "Enables web assembly code execution"));
+                packCommand.IsHidden = true;
 
                 packCommand.Handler = CommandHandler.Create<PackOptions, IConsole>(
                     (options, console) =>
@@ -363,17 +408,19 @@ namespace MLS.Agent.CommandLine
 
             Command Install()
             {
-                var installCommand = new Command("install", "Install a Try .NET package");
-                installCommand.AddArgument(new Argument<string>
+                var installCommand = new Command("install", "Install a Try .NET package")
                 {
-                    Name = nameof(InstallOptions.PackageName)
-                });
+                    new Argument<string>
+                    {
+                        Name = nameof(InstallOptions.PackageName)
+                    },
+                    new Option("--add-source")
+                    {
+                        Argument = new Argument<PackageSource>()
+                    }
+                };
+
                 installCommand.IsHidden = true;
-
-                var option = new Option("--add-source",
-                                        argument: new Argument<PackageSource>());
-
-                installCommand.AddOption(option);
 
                 installCommand.Handler = CommandHandler.Create<InstallOptions, IConsole>((options, console) => install(options, console));
 

--- a/MLS.Agent/MLS.Agent.csproj
+++ b/MLS.Agent/MLS.Agent.csproj
@@ -86,7 +86,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19317.1" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
     <PackageReference Include="TaskExtensions" Version="0.1.8580001">
       <PrivateAssets>all</PrivateAssets>

--- a/MLS.Agent/Markdown/LocalCodeFenceAnnotationsParser.cs
+++ b/MLS.Agent/Markdown/LocalCodeFenceAnnotationsParser.cs
@@ -90,8 +90,10 @@ namespace MLS.Agent.Markdown
                 Arity = ArgumentArity.ZeroOrOne
             };
 
-            var sourceFileOption = new Option("--source-file",
-                                              argument: sourceFileArg);
+            var sourceFileOption = new Option("--source-file")
+            {
+                Argument = sourceFileArg
+            };
 
             command.AddOption(sourceFileOption);
         }
@@ -151,8 +153,10 @@ namespace MLS.Agent.Markdown
                 return null;
             });
 
-            var projectOption = new Option("--project",
-                argument: projectOptionArgument);
+            var projectOption = new Option("--project")
+            {
+                Argument = projectOptionArgument
+            };
 
             command.Add(projectOption);
         }

--- a/MLS.PackageTool/MLS.PackageTool.csproj
+++ b/MLS.PackageTool/MLS.PackageTool.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
+++ b/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.17.0" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/Microsoft.DotNet.Try.ProjectTemplate/Tutorial/content/Microsoft.DotNet.Try.ProjectTemplate.Tutorial.csproj
+++ b/Microsoft.DotNet.Try.ProjectTemplate/Tutorial/content/Microsoft.DotNet.Try.ProjectTemplate.Tutorial.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/Beginners/myapp/myapp.csproj
+++ b/Samples/Beginners/myapp/myapp.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/csharp8/ExploreCsharpEight/ExploreCsharpEight.csproj
+++ b/Samples/csharp8/ExploreCsharpEight/ExploreCsharpEight.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 
 </Project>

--- a/WasmCodeRunner/CommandLineBuilderExtensions.cs
+++ b/WasmCodeRunner/CommandLineBuilderExtensions.cs
@@ -108,8 +108,10 @@ namespace MLS.WasmCodeRunner
 
             var option = new Option(
                 parameter.BuildAlias(),
-                parameter.ValueName,
-                argument);
+                parameter.ValueName)
+            {
+                Argument = argument
+            };
 
             return option;
         }

--- a/WasmCodeRunner/MLS.WasmCodeRunner.csproj
+++ b/WasmCodeRunner/MLS.WasmCodeRunner.csproj
@@ -8,6 +8,6 @@
   
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 </Project>

--- a/WorkspaceServer/Packaging/BlazorPackageInitializer.cs
+++ b/WorkspaceServer/Packaging/BlazorPackageInitializer.cs
@@ -56,7 +56,7 @@ namespace WorkspaceServer.Packaging
                 await dotnet.AddPackage(packageId);
             }
 
-            await dotnet.AddPackage("System.CommandLine.Experimental", "0.3.0-alpha.19312.1");
+            await dotnet.AddPackage("System.CommandLine.Experimental", "0.3.0-alpha.19317.1");
 
             var result = await dotnet.Build("-o runtime /bl", budget: budget);
             var stuff = string.Concat(string.Join("\n", result.Output), (string.Join("\n", result.Error)));

--- a/WorkspaceServer/WorkspaceServer.csproj
+++ b/WorkspaceServer/WorkspaceServer.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.1.0-beta3-final" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="NewtonSoft.Json" Version="11.0.2" />
-    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19317.1" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
     <PackageReference Include="Pocket.Disposable" Version="1.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/docs/GettingStarted/Snippets/Snippets.csproj
+++ b/docs/GettingStarted/Snippets/Snippets.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19312.1" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19312.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This includes some code changes due to API changes in System.CommandLine to reduce the number of constructor parameters for options and commands. 

Thoughts?