### PR TITLE
Fix blazor exception by changing content root

### DIFF
--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -120,7 +120,7 @@ namespace MLS.Agent
 
             var webHost = new WebHostBuilder()
                           .UseKestrel()
-                          .UseContentRoot(Directory.GetCurrentDirectory())
+                          .UseContentRoot(Path.GetDirectoryName(typeof(Program).Assembly.Location))
                           .ConfigureServices(c =>
                           {
                               if (!string.IsNullOrEmpty(options.ApplicationInsightsKey))


### PR DESCRIPTION
Content root needs to contain the mls.blazor assembly, apparently.