### PR TITLE
Should use 4242 if not in try mode

### DIFF
--- a/MLS.Agent.Tests/AgentService.cs
+++ b/MLS.Agent.Tests/AgentService.cs
@@ -70,7 +70,7 @@ namespace MLS.Agent.Tests
                           })
                           .UseTestEnvironment()
                           .UseStartup<Startup>()
-                          .ConfigureUrlUsingPort(_options.Port);
+                          .ConfigureUrlUsingPort(_options.Mode, _options.Port);
 
             return builder;
         }

--- a/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
+++ b/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using MLS.Agent.CommandLine;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -11,23 +12,23 @@ namespace MLS.Agent.Tests
     public class WebHostBuilderExtensionTests
     {
         [Fact]
-        public void If_launched_for_development_4242_is_used()
+        public void If_not_in_try_mode_4242_is_used_and_protocol_is_http()
         {
-            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(true, null);
+            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(StartupMode.Hosted, null);
             uri.ToString().Should().Be("http://localhost:4242/");
         }
 
         [Fact]
-        public void If_not_launched_for_development_and_port_is_specified_it_is_used()
+        public void If_in_try_mode_and_port_is_specified_it_is_used()
         {
-            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, 6000);
+            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(StartupMode.Try, 6000);
             uri.ToString().Should().Be("https://localhost:6000/");
         }
 
         [Fact]
-        public void If_not_launched_for_development_and_port_is_not_specified_a_free_port_is_returned()
+        public void If_in_try_mode_and_port_is_not_specified_a_free_port_is_returned()
         {
-            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, null);
+            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(StartupMode.Try, null);
             uri.AbsoluteUri.Should().Match("https://localhost:*/");
             CheckIfPortIsAvailable(uri.Port).Should().BeTrue();
         }

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -137,7 +137,7 @@ namespace MLS.Agent
                           })
                           .UseEnvironment(options.EnvironmentName)
                           .UseStartup<Startup>()
-                          .ConfigureUrlUsingPort(options.Port)
+                          .ConfigureUrlUsingPort(options.Port, options.Mode)
                           .Build();
 
             return webHost;

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -137,7 +137,7 @@ namespace MLS.Agent
                           })
                           .UseEnvironment(options.EnvironmentName)
                           .UseStartup<Startup>()
-                          .ConfigureUrlUsingPort(options.Port, options.Mode)
+                          .ConfigureUrlUsingPort(options.Mode, options.Port)
                           .Build();
 
             return webHost;

--- a/MLS.Agent/Properties/launchSettings.json
+++ b/MLS.Agent/Properties/launchSettings.json
@@ -18,12 +18,11 @@
     },
     "MLS.Agent": {
       "commandName": "Project",
-      "commandLineArgs": "try C:/Users/dicolomb/source/repos/Public/TryDotNet.XamU.CSharp",
+      "commandLineArgs": "try",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:4242"
+      }
     },
     "Hosted": {
       "commandName": "Project",

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -11,15 +11,15 @@ namespace MLS.Agent
 {
     public static class WebHostBuilderExtensions
     {
-        public static IWebHostBuilder ConfigureUrlUsingPort(this IWebHostBuilder builder, int? port)
+        public static IWebHostBuilder ConfigureUrlUsingPort(this IWebHostBuilder builder, StartupMode mode, int? port)
         {
-            var uri = GetBrowserLaunchUri(IsLaunchedForDevelopment(), port);
+            var uri = GetBrowserLaunchUri(mode, port);
             return builder.UseUrls(uri.ToString());
         }
 
-        public static Uri GetBrowserLaunchUri(bool isLaunchedForDevelopment, int? port)
+        public static Uri GetBrowserLaunchUri(StartupMode mode, int? port)
         {
-            if (isLaunchedForDevelopment)
+            if (mode != StartupMode.Try)
             {
                return new Uri("http://localhost:4242");
             }
@@ -31,12 +31,6 @@ namespace MLS.Agent
             {
                 return new Uri($"https://localhost:{GetFreePort()}");
             }
-        }
-
-        private static bool IsLaunchedForDevelopment()
-        {
-            var processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
-            return processName == "dotnet" || processName == "dotnet.exe";
         }
 
         private static int GetFreePort()


### PR DESCRIPTION
Currently if we launch in try mode using Visual Studio then we launch on 4242, otherwise if we launch from the command line it runs on an arbitrary port and uses https. It would be good if the behavior when we run with F5 is the same as when the tool is run so that if there is an issue when running the tool from the command line, it can also be reproduced using F5 in Visual Studio.

The switching based on mode is also important because as per the settings we have been using so far the agent was assumed to be running on http://localhost:4242 and we should retain that behavior as we change our dockerimage to consume the tool.