### PR TITLE
When in hosted mode do not enforce localhost

### DIFF
--- a/MLS.Agent.Tests/AgentService.cs
+++ b/MLS.Agent.Tests/AgentService.cs
@@ -70,7 +70,7 @@ namespace MLS.Agent.Tests
                           })
                           .UseTestEnvironment()
                           .UseStartup<Startup>()
-                          .ConfigureUrlUsingPort(_options.Port);
+                          .ConfigureUrl(_options.Mode, _options.Port);
 
             return builder;
         }

--- a/MLS.Agent.Tests/DocumentationAPITests.cs
+++ b/MLS.Agent.Tests/DocumentationAPITests.cs
@@ -224,7 +224,7 @@ namespace MLS.Agent.Tests
                      .LaunchedUri
                      .ToString()
                      .Should()
-                     .Match("http://localhost:*/something.md");
+                     .Match("https://localhost:*/something.md");
             }
         }
 
@@ -252,7 +252,7 @@ namespace MLS.Agent.Tests
                     .LaunchedUri
                     .ToString()
                     .Should()
-                    .Match("http://localhost:*/readme.md");
+                    .Match("https://localhost:*/readme.md");
             }
         }
     }

--- a/MLS.Agent.Tests/MLS.Agent.Tests.v3.ncrunchproject
+++ b/MLS.Agent.Tests/MLS.Agent.Tests.v3.ncrunchproject
@@ -1,7 +1,0 @@
-﻿<ProjectConfiguration>
-  <Settings>
-    <HiddenComponentWarnings>
-      <Value>AspNetTestHostCompatibility</Value>
-    </HiddenComponentWarnings>
-  </Settings>
-</ProjectConfiguration>

--- a/MLS.Agent.Tests/MLS.Agent.Tests.v3.ncrunchproject
+++ b/MLS.Agent.Tests/MLS.Agent.Tests.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <HiddenComponentWarnings>
+      <Value>AspNetTestHostCompatibility</Value>
+    </HiddenComponentWarnings>
+  </Settings>
+</ProjectConfiguration>

--- a/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
+++ b/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
@@ -3,11 +3,8 @@
 
 using FluentAssertions;
 using MLS.Agent.CommandLine;
-using System;
 using System.Linq;
-using System.Net;
 using System.Net.NetworkInformation;
-using System.Text.RegularExpressions;
 using Xunit;
 namespace MLS.Agent.Tests
 {
@@ -19,7 +16,7 @@ namespace MLS.Agent.Tests
         public void If_launched_for_development_localhost_4242_is_used_irrespective_of_mode(StartupMode mode)
         {
             var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(true, mode, null);
-            uri.Should().Be("https://localhost:4242");
+            uri.ToString().Should().Be("https://localhost:4242");
         }
 
         public class WhenNotLaunchedForDevelopment
@@ -31,7 +28,7 @@ namespace MLS.Agent.Tests
             public void If_port_is_not_specified_a_free_port_is_returned(StartupMode mode)
             {
                 var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, mode, null);
-                CheckIfPortIsAvailable(GetPort(uri)).Should().BeTrue();
+                CheckIfPortIsAvailable(uri.Port).Should().BeTrue();
             }
 
             [Theory]
@@ -40,46 +37,22 @@ namespace MLS.Agent.Tests
             public void If_a_port_it_specified_it_is_used(StartupMode mode)
             {
                 var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, mode, 6000);
-                GetPort(uri).Should().Be(6000);
+                uri.Port.Should().Be(6000);
             }
 
             [Fact]
             public void In_try_mode_host_should_be_localhost()
             {
                 var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, StartupMode.Try, 6000);
-                GetHost(uri).Should().Be("localhost");
+                uri.Host.Should().Be("localhost");
             }
 
             [Fact]
             public void In_hosted_mode_host_should_be_star()
             {
                 var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(false, StartupMode.Hosted, 6000);
-                GetHost(uri).Should().Be("*");
+                uri.Host.Should().Be("*");
             }
-        }
-
-        private static ushort GetPort(string uri)
-        {
-            if(Uri.TryCreate(uri, UriKind.Absolute, out var result))
-            {
-                return Convert.ToUInt16(result.Port);
-            }
-
-            Regex r = new Regex(@"^(?<host>.+):(?<port>\d+)$");
-            Match m = r.Match(uri);
-            return Convert.ToUInt16(m.Groups["port"].Value);
-        }
-
-        private static string GetHost(string uri)
-        {
-            if (Uri.TryCreate(uri, UriKind.Absolute, out var result))
-            {
-                return result.Host;
-            }
-
-            Regex r = new Regex(@"^(?<proto>.+)://(?<host>.+):(?<port>\d+)$");
-            Match m = r.Match(uri);
-            return m.Groups["host"].Value;
         }
 
         private static bool CheckIfPortIsAvailable(ushort port)

--- a/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
+++ b/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
@@ -19,7 +19,7 @@ namespace MLS.Agent.Tests
         public void If_launched_for_development_localhost_4242_is_used_irrespective_of_mode(StartupMode mode)
         {
             var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(true, mode, null);
-            uri.Should().Be("http://localhost:4242");
+            uri.Should().Be("https://localhost:4242");
         }
 
         public class WhenNotLaunchedForDevelopment

--- a/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
+++ b/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using MLS.Agent.CommandLine;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -10,10 +11,11 @@ namespace MLS.Agent.Tests
 {
     public class WebHostBuilderExtensionTests
     {
-        [Fact]
-        public void If_launched_for_development_4242_is_used()
+        [Theory]
+        [Inline()]
+        public void If_launched_for_development_localhost_4242_is_used_irrespective_of_mode()
         {
-            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(true, null);
+            var uri = WebHostBuilderExtensions.GetBrowserLaunchUri(true, StartupMode,null);
             uri.ToString().Should().Be("http://localhost:4242/");
         }
 

--- a/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
+++ b/MLS.Agent.Tests/WebHostBuilderExtensionTests.cs
@@ -58,16 +58,16 @@ namespace MLS.Agent.Tests
             }
         }
 
-        private static long GetPort(string uri)
+        private static ushort GetPort(string uri)
         {
             if(Uri.TryCreate(uri, UriKind.Absolute, out var result))
             {
-                return result.Port;
+                return Convert.ToUInt16(result.Port);
             }
 
             Regex r = new Regex(@"^(?<host>.+):(?<port>\d+)$");
             Match m = r.Match(uri);
-            return Convert.ToInt64(m.Groups["port"].Value);
+            return Convert.ToUInt16(m.Groups["port"].Value);
         }
 
         private static string GetHost(string uri)
@@ -82,7 +82,7 @@ namespace MLS.Agent.Tests
             return m.Groups["host"].Value;
         }
 
-        private static bool CheckIfPortIsAvailable(long port)
+        private static bool CheckIfPortIsAvailable(ushort port)
         {
             // Evaluate current system tcp connections. This is the same information provided
             // by the netstat command line application, just in .Net strongly-typed object
@@ -91,7 +91,7 @@ namespace MLS.Agent.Tests
             IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
             TcpConnectionInformation[] tcpConnInfoArray = ipGlobalProperties.GetActiveTcpConnections();
 
-            return tcpConnInfoArray.FirstOrDefault(tcpi => tcpi.LocalEndPoint.Port == (int)port) == null;
+            return tcpConnInfoArray.FirstOrDefault(tcpi => tcpi.LocalEndPoint.Port == port) == null;
         }
     }
 }

--- a/MLS.Agent/BrowserLaunchUri.cs
+++ b/MLS.Agent/BrowserLaunchUri.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MLS.Agent
+{
+    public class BrowserLaunchUri
+    {
+        public BrowserLaunchUri(string scheme, string host, ushort port)
+        {
+            Scheme = scheme ?? throw new ArgumentNullException(nameof(scheme));
+            Host = host ?? throw new ArgumentNullException(nameof(host));
+            Port = port;
+        }
+
+        public string Scheme { get; }
+        public string Host { get; }
+        public ushort Port { get; }
+
+        public override string ToString()
+        {
+            return $"{Scheme}://{Host}:{Port}";
+        }
+    }
+}

--- a/MLS.Agent/Program.cs
+++ b/MLS.Agent/Program.cs
@@ -140,7 +140,7 @@ namespace MLS.Agent
                           })
                           .UseEnvironment(options.EnvironmentName)
                           .UseStartup<Startup>()
-                          .ConfigureUrlUsingPort(options.Port)
+                          .ConfigureUrl(options.Mode, options.Port)
                           .Build();
 
             return webHost;

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace MLS.Agent
             var scheme = "https";
             if (isLaunchedForDevelopment)
             {
-                return new BrowserLaunchUri(scheme, "localhost",4242);
+                return new BrowserLaunchUri(scheme, "localhost", 4242);
             }
 
             var portToUse = port.HasValue ? port : GetFreePort();

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -11,26 +11,23 @@ namespace MLS.Agent
 {
     public static class WebHostBuilderExtensions
     {
-        public static IWebHostBuilder ConfigureUrlUsingPort(this IWebHostBuilder builder, int? port)
+        public static IWebHostBuilder ConfigureUrlUsingPort(this IWebHostBuilder builder, StartupMode mode,  int? port)
         {
-            var uri = GetBrowserLaunchUri(IsLaunchedForDevelopment(), port);
+            var uri = GetBrowserLaunchUri(IsLaunchedForDevelopment(), mode, port);
             return builder.UseUrls(uri.ToString());
         }
 
-        public static Uri GetBrowserLaunchUri(bool isLaunchedForDevelopment, int? port)
+        public static Uri GetBrowserLaunchUri(bool isLaunchedForDevelopment, StartupMode mode, int? port)
         {
             if (isLaunchedForDevelopment)
             {
                return new Uri("http://localhost:4242");
             }
-            else if (port.HasValue)
-            {
-                return new Uri($"https://localhost:{port}");
-            }
-            else
-            {
-                return new Uri($"https://localhost:{GetFreePort()}");
-            }
+
+            var portToUse = port.HasValue?port: GetFreePort();
+            var domain = mode == StartupMode.Hosted ? "*" : "localhost";
+
+            return new Uri($"https://{domain}:{portToUse}");
         }
 
         private static bool IsLaunchedForDevelopment()

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Hosting;
@@ -44,25 +43,6 @@ namespace MLS.Agent
             int port = ((IPEndPoint)l.LocalEndpoint).Port;
             l.Stop();
             return (ushort)port;
-        }
-    }
-
-    public class BrowserLaunchUri
-    {
-        public BrowserLaunchUri(string protocol, string host, ushort port)
-        {
-            Scheme = protocol ?? throw new ArgumentNullException(nameof(protocol));
-            Host = host ?? throw new ArgumentNullException(nameof(host));
-            Port = port;
-        }
-
-        public string Scheme { get; }
-        public string Host { get; }
-        public ushort Port { get; }
-
-        public override string ToString()
-        {
-            return $"{Scheme}://{Host}:{Port}";
         }
     }
 }

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace MLS.Agent
         {
             if (isLaunchedForDevelopment)
             {
-                return "http://localhost:4242";
+                return "https://localhost:4242";
             }
 
             var portToUse = port.HasValue ? port : GetFreePort();

--- a/MLS.Agent/WebHostBuilderExtensions.cs
+++ b/MLS.Agent/WebHostBuilderExtensions.cs
@@ -11,23 +11,23 @@ namespace MLS.Agent
 {
     public static class WebHostBuilderExtensions
     {
-        public static IWebHostBuilder ConfigureUrlUsingPort(this IWebHostBuilder builder, StartupMode mode,  int? port)
+        public static IWebHostBuilder ConfigureUrl(this IWebHostBuilder builder, StartupMode mode, int? port)
         {
             var uri = GetBrowserLaunchUri(IsLaunchedForDevelopment(), mode, port);
             return builder.UseUrls(uri.ToString());
         }
 
-        public static Uri GetBrowserLaunchUri(bool isLaunchedForDevelopment, StartupMode mode, int? port)
+        public static string GetBrowserLaunchUri(bool isLaunchedForDevelopment, StartupMode mode, int? port)
         {
             if (isLaunchedForDevelopment)
             {
-               return new Uri("http://localhost:4242");
+                return "http://localhost:4242";
             }
 
-            var portToUse = port.HasValue?port: GetFreePort();
+            var portToUse = port.HasValue ? port : GetFreePort();
             var domain = mode == StartupMode.Hosted ? "*" : "localhost";
 
-            return new Uri($"https://{domain}:{portToUse}");
+            return $"https://{domain}:{portToUse}";
         }
 
         private static bool IsLaunchedForDevelopment()


### PR DESCRIPTION
When we run the agent image in the docker, if we set the url host to "localhost", then in the docker image the process would only listen to requests from within the docker and external processes will not be able to send requests to it inspite of the port binding. 

Hence it hosted mode, we can still use the port specified by --port argument but not explicitly use "localhost"

More context: https://blog.scottlogic.com/2016/09/05/hosting-netcore-on-linux-with-docker.html