### PR TITLE
add up-to-date CI check

### DIFF
--- a/MLS.Agent/MLS.Agent.csproj
+++ b/MLS.Agent/MLS.Agent.csproj
@@ -148,7 +148,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="BuildCss" Inputs="@$(CssInputFiles)" DependsOnTargets="GatherInputs" Outputs="$(CssOutputFile)" BeforeTargets="BeforeBuild" Condition="'$(NCrunch)' != '1' And '$(BuildingInsideVisualStudio)' != 'true'">
+  <Target Name="BuildCss" Inputs="@(CssInputFiles)" DependsOnTargets="GatherInputs" Outputs="$(CssOutputFile)" BeforeTargets="BeforeBuild" Condition="'$(NCrunch)' != '1' And '$(BuildingInsideVisualStudio)' != 'true'">
 
     <PropertyGroup>
       <_TryDotNetCssExists Condition="Exists('$(CssOutputFile)')">true</_TryDotNetCssExists>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ variables:
     value: 3.0.0-preview6.19307.2
   - name: DotNetSdkVersion
     value: 3.0.100-preview6-012264
+  - name: NodeJSVersion
+    value: '>=12'
   - name: TryDotNetPackagesPath
     value: $(Build.SourcesDirectory)/artifacts/.trydotnet/packages
 
@@ -70,7 +72,7 @@ jobs:
       - task: NodeTool@0
         displayName: Add NodeJS/npm
         inputs:
-          versionSpec: '>=12'
+          versionSpec: $(NodeJSVersion)
 
       - task: UseDotNet@2
         displayName: Add dotnet
@@ -208,7 +210,7 @@ jobs:
       - task: NodeTool@0
         displayName: Add NodeJS/npm
         inputs:
-          versionSpec: '>=12'
+          versionSpec: $(NodeJSVersion)
 
       - task: UseDotNet@2
         displayName: Add dotnet
@@ -241,3 +243,28 @@ jobs:
           searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
         continueOnError: true
         condition: always()
+
+    # Up-to-date
+    - job: UpToDate_Windows
+      pool:
+        vmImage: windows-2019
+      steps:
+      - checkout: self
+        clean: true
+      - task: NodeTool@0
+        displayName: Add NodeJS/npm
+        inputs:
+          versionSpec: $(NodeJSVersion)
+      - task: UseDotNet@2
+        displayName: Add dotnet
+        inputs:
+          packageType: sdk
+          version: $(DotNetSdkVersion)
+          installationPath: $(Agent.ToolsDirectory)/dotnet
+      - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
+        displayName: Install Blazor templates
+      - task: PowerShell@2
+        displayName: Run up-to-date build check
+        inputs:
+          filePath: eng\tests\UpToDate.ps1
+          arguments: -configuration $(_BuildConfig) -restore -ci

--- a/eng/tests/UpToDate.ps1
+++ b/eng/tests/UpToDate.ps1
@@ -1,0 +1,72 @@
+# This script verifies that subsequent calls to `build.cmd` don't cause js/css to be unnecessarily rebuilt.
+
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [string][Alias('c')]$configuration = "Debug",
+    [parameter(ValueFromRemainingArguments=$true)][string[]]$properties
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $RepoRoot = Join-Path $PSScriptRoot ".." | Join-Path -ChildPath ".." -Resolve
+    $BuildScript = Join-Path $RepoRoot "build.cmd"
+
+    # do first build
+    & $BuildScript -configuration $configuration @properties
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error running first build."
+        exit 1
+    }
+
+    # list of sentinel files to check
+    $FileList = @(
+        "$RepoRoot\MLS.Agent\wwwroot\api\trydotnet.min.js",
+        "$RepoRoot\MLS.Agent\wwwroot\client\bundle.js",
+        "$RepoRoot\MLS.Agent\wwwroot\css\trydotnet.css"
+    )
+
+    # gather file timestamps
+    $InitialFilesAndTimes = @{}
+    foreach ($f in $FileList) {
+        $LastWriteTime = (Get-Item $f).LastWriteTimeUtc
+        $InitialFilesAndTimes.Add($f, $LastWriteTime)
+    }
+
+    # build again
+    & $BuildScript -configuration $configuration @properties
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error running second build."
+        exit 1
+    }
+
+    # gather file timestamps again
+    $FinalFilesAndTimes = @{}
+    foreach ($f in $FileList) {
+        $LastWriteTime = (Get-Item $f).LastWriteTimeUtc
+        $FinalFilesAndTimes.Add($f, $LastWriteTime)
+    }
+
+    # validate that file timestamps haven't changed
+    $RebuiltFiles = @()
+    foreach ($f in $FileList) {
+        $InitialTime = $InitialFilesAndTimes[$f]
+        $FinalTime = $FinalFilesAndTimes[$f]
+        if ($InitialTime -ne $FinalTime) {
+            $RebuiltFiles += $f
+        }
+    }
+
+    $FileCount = $FileList.Length
+    $RebuiltCount = $RebuiltFiles.Length
+    Write-Host "$RebuiltCount of $FileCount files were re-built."
+    $RebuiltFiles | ForEach-Object { Write-Host "    $_" }
+    exit $RebuiltCount
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/eng/tests/UpToDate.ps1
+++ b/eng/tests/UpToDate.ps1
@@ -21,11 +21,7 @@ try {
     }
 
     # list of sentinel files to check
-    $FileList = @(
-        "$RepoRoot\MLS.Agent\wwwroot\api\trydotnet.min.js",
-        "$RepoRoot\MLS.Agent\wwwroot\client\bundle.js",
-        "$RepoRoot\MLS.Agent\wwwroot\css\trydotnet.css"
-    )
+    $FileList = Get-ChildItem -Path "$RepoRoot\MLS.Agent\wwwroot" -Recurse -File | %{ $_.FullName }
 
     # gather file timestamps
     $InitialFilesAndTimes = @{}


### PR DESCRIPTION
Copying from [`dotnet/fsharp`](https://github.com/dotnet/fsharp), adding a CI step to verify we don't unnecessarily rebuild the `node` dependencies.  The process is to build the solution, gather the modification timestamp from some sentinel files, build again, and verify the timestamps haven't changed, indicating a rebuild.

Check the `$FileList` array in `UpToDate.ps1` for the list of sentinel files that we check.
