### PR TITLE
update internal builds to use VS2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
           vmImage: windows-2019
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           name: NetCoreInternal-Int-Pool
-          queue: buildpool.windows.10.amd64.vs2017
+          queue: buildpool.windows.10.amd64.vs2019
       variables:
       # Enable signing for internal, non-PR builds
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Internal build ~~is [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=279494) waiting for completion~~ has passed.

This brings our PR and internal builds in line to use the same version of VS.  Previously there were machine setup issues that prevented this, but they've been fixed now.