### PR TITLE
Add UseExtendDirective to Jupyter

### DIFF
--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -381,6 +381,7 @@ namespace MLS.Agent.CommandLine
                             new CSharpKernel()
                                 .UseDefaultRendering()
                                 .UseNugetDirective()
+                                .UseExtendDirective()
                         })
                         .AddSingleton(c => new JupyterRequestContextHandler(
                                               c.GetRequiredService<PackageRegistry>(),


### PR DESCRIPTION
Call UseExtendDirective() during startup so `#extend` directives will be handled correctly.