### PR TITLE
Add DisplayValue command and use AssemblyLoadContext for #extend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 .trydotnet-*
+.dotnet/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Microsoft.DotNet.Interactive/Commands/DisplayValue.cs
+++ b/Microsoft.DotNet.Interactive/Commands/DisplayValue.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive.Commands
+{
+    public class DisplayValue : KernelCommandBase
+    {
+        public DisplayValue(FormattedValue formattedValue)
+        {
+            FormattedValue = formattedValue;
+        }
+
+        public FormattedValue FormattedValue { get; }
+    }
+}

--- a/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -10,7 +10,7 @@ using System.CommandLine.Invocation;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
-using System.Reflection;
+using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Interactive
             KernelPipelineContext pipelineContext,
             KernelPipelineContinuation next)
         {
-            var assembly = Assembly.LoadFile(loadExtension.AssemblyFile.FullName);
+            var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(loadExtension.AssemblyFile.FullName);
 
             var extensionTypes = assembly
                                  .ExportedTypes

--- a/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
+++ b/Microsoft.DotNet.Interactive/Microsoft.DotNet.Interactive.csproj
@@ -7,6 +7,7 @@
     <!-- Clockwise isn't strongly signed -->
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Reactive" Version="4.1.5" />
     <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19317.1" />
         <PackageReference Include="PocketLogger" Version="0.3.0">


### PR DESCRIPTION
1. Add a DisplayValue command that allows extensions to display a specific value.
2. When loading extensions, don't use Assembly.LoadFile, since that loads assemblies in a different AssemblyLoadContext. Instead, since this is .NET Core, we can use AssemblyLoadContext.Default.