### PR TITLE
update install script to be arcade-aware

### DIFF
--- a/MLS.Agent/build-and-install-global-tool.ps1
+++ b/MLS.Agent/build-and-install-global-tool.ps1
@@ -1,7 +1,18 @@
-function Get-ScriptDirectory {
-    Split-Path -parent $PSCommandPath
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+$thisDir = Split-Path -Parent $PSCommandPath
+$toolLocation = ""
+$toolVersion = ""
+if (Test-Path '$env:DisableArcade') {
+    dotnet pack "$thisDir\MLS.Agent.csproj" /p:Version=0.0.0
+    $script:toolLocation = "$thisDir\bin\debug"
+    $script:toolVersion = "0.0.0"
+} else {
+    & "$thisDir\..\build.cmd" -pack
+    $script:toolLocation = "$thisDir\..\artifacts\packages\Debug\Shipping"
+    $script:toolVersion = "1.0.44142.42"
 }
 
-dotnet pack /p:Version=0.0.0
 dotnet tool uninstall -g dotnet-try
-dotnet tool install -g --add-source "$(Get-ScriptDirectory)/bin/debug" --version 0.0.0 dotnet-try
+dotnet tool install -g --add-source "$toolLocation" --version $toolVersion dotnet-try


### PR DESCRIPTION
This script assumes (incorrectly?  I'm open to discussion) that `.\restore.cmd` has already been run.