### PR TITLE
Show error and message both when commandline result has failure

### DIFF
--- a/MLS.Agent.Tools/CommandLineResultExtensions.cs
+++ b/MLS.Agent.Tools/CommandLineResultExtensions.cs
@@ -12,7 +12,7 @@ namespace MLS.Agent.Tools
         {
             if (result.ExitCode != 0)
             {
-                throw new CommandLineInvocationException(result, message + "\n" + string.Join("\n", result.Error.Concat(result.Output)));
+                throw new CommandLineInvocationException(result, $"{message}{Environment.NewLine}{string.Join(Environment.NewLine, result.Error.Concat(result.Output))}");
             }
         }
     }

--- a/MLS.Agent.Tools/CommandLineResultExtensions.cs
+++ b/MLS.Agent.Tools/CommandLineResultExtensions.cs
@@ -12,7 +12,7 @@ namespace MLS.Agent.Tools
         {
             if (result.ExitCode != 0)
             {
-                throw new CommandLineInvocationException(result, message ?? string.Join("\n", result.Error.Concat(result.Output)));
+                throw new CommandLineInvocationException(result, message + "\n" + string.Join("\n", result.Error.Concat(result.Output)));
             }
         }
     }

--- a/MLS.Agent.Tools/CommandLineResultExtensions.cs
+++ b/MLS.Agent.Tools/CommandLineResultExtensions.cs
@@ -12,7 +12,7 @@ namespace MLS.Agent.Tools
         {
             if (result.ExitCode != 0)
             {
-                throw new CommandLineInvocationException(result, $"{message}{Environment.NewLine}{string.Join(Environment.NewLine, result.Error.Concat(result.Output))}");
+                throw new CommandLineInvocationException(result, $"{message ?? string.Empty}{Environment.NewLine}{string.Join(Environment.NewLine, result.Error.Concat(result.Output))}");
             }
         }
     }


### PR DESCRIPTION
The motivation for this change is that while i was using dotnet  try pack, there was some issue of permissions for nuget dependencies due to which pack was failing however i was only seeing the error `Failed to build intermediate project` that made it really hard to understand the issue.

When the result.ThrowOnException occurs we should show the error and the output to the users