### PR TITLE
Fix verify command

### DIFF
--- a/MLS.Agent.Tests/CommandLine/DemoCommandTests.cs
+++ b/MLS.Agent.Tests/CommandLine/DemoCommandTests.cs
@@ -38,8 +38,7 @@ namespace MLS.Agent.Tests.CommandLine
             var resultCode = await VerifyCommand.Do(
                                  new VerifyOptions(dir: outputDirectory),
                                  console,
-                                 () => new FileSystemDirectoryAccessor(outputDirectory),
-                                 new PackageRegistry(),
+                                 (dir) => new FileSystemDirectoryAccessor(dir),
                                  startupOptions: new StartupOptions(package: packageFile.FullName));
 
             _output.WriteLine(console.Out.ToString());
@@ -65,8 +64,7 @@ namespace MLS.Agent.Tests.CommandLine
             var resultCode = await VerifyCommand.Do(
                                  new VerifyOptions(dir: demoSourcesDir),
                                  console,
-                                 () => new FileSystemDirectoryAccessor(demoSourcesDir),
-                                 new PackageRegistry(),
+                                 (dir) => new FileSystemDirectoryAccessor(dir),
                                  new StartupOptions(package: packageFile.FullName));
 
             _output.WriteLine(console.Out.ToString());
@@ -112,8 +110,7 @@ namespace MLS.Agent.Tests.CommandLine
             var resultCode = await VerifyCommand.Do(
                                  new VerifyOptions(dir: outputDirectory),
                                  console,
-                                 () => new FileSystemDirectoryAccessor(outputDirectory),
-                                 new PackageRegistry());
+                                 (dir) => new FileSystemDirectoryAccessor(dir));
 
             resultCode.Should().NotBe(0);
         }
@@ -134,8 +131,7 @@ namespace MLS.Agent.Tests.CommandLine
             await VerifyCommand.Do(
                 new VerifyOptions(dir: outputDirectory),
                 console,
-                () => new FileSystemDirectoryAccessor(outputDirectory),
-                new PackageRegistry());
+                (dir) => new FileSystemDirectoryAccessor(dir));
 
             _output.WriteLine(console.Out.ToString());
             _output.WriteLine(console.Error.ToString());

--- a/MLS.Agent.Tests/CommandLine/VerifyCommandTests.cs
+++ b/MLS.Agent.Tests/CommandLine/VerifyCommandTests.cs
@@ -92,8 +92,7 @@ This is some sample code:
                 await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root));
+                    (dir) => directoryAccessor);
 
                 console.Out
                     .ToString()
@@ -121,8 +120,7 @@ This is some sample code:
                 await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root));
+                    (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -156,8 +154,7 @@ This is some sample code:
                 await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root));
+                    (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -198,8 +195,7 @@ public class EmptyClassTwo {}
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root));
+                    (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -230,8 +226,7 @@ public class EmptyClassTwo {}
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root));
+                    (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -258,8 +253,7 @@ public class EmptyClassTwo {}
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root));
+                    (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -286,8 +280,7 @@ public class EmptyClassTwo {}
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     PackageRegistry.CreateForTryMode(rootDirectory));
+                                     (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -328,8 +321,7 @@ public class Program
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     PackageRegistry.CreateForTryMode(rootDirectory));
+                                     (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -349,8 +341,7 @@ public class Program
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     PackageRegistry.CreateForTryMode(rootDirectory));
+                                     (dir) => directoryAccessor);
 
                 console.Error.ToString().Should().Contain("No markdown files found");
                 resultCode.Should().NotBe(0);
@@ -383,8 +374,7 @@ public class Program
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     PackageRegistry.CreateForTryMode(rootDirectory));
+                                     (dir) => directoryAccessor);
 
                 console.Out.ToString().Should().Contain("Session cannot span projects or packages: --session one");
 
@@ -429,8 +419,7 @@ public class Program
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(directory),
                                      console,
-                                     () => directoryAccessor,
-                                     PackageRegistry.CreateForTryMode(directory));
+                                     (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -470,8 +459,7 @@ public class Program
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     PackageRegistry.CreateForTryMode(rootDirectory));
+                                     (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -519,8 +507,7 @@ public class Program
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(rootDirectory),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(rootDirectory));
+                    (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -550,8 +537,7 @@ This is some sample code:
                 await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root));
+                    (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -589,12 +575,10 @@ This is some sample code:
 
                 var console = new TestConsole();
 
-                var packageRegistry = PackageRegistry.CreateForTryMode(rootDirectory);
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     packageRegistry);
+                                     (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
                 resultCode.Should().Be(0);
@@ -604,8 +588,7 @@ This is some sample code:
                 resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     packageRegistry);
+                                     (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -659,12 +642,11 @@ This is some sample code:
 
                 var console = new TestConsole();
 
-                var packageRegistry = PackageRegistry.CreateForTryMode(rootDirectory);
+               
                 var resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     packageRegistry);
+                                     (dir) => directoryAccessor);
 
                 resultCode.Should().Be(0);
 
@@ -673,8 +655,7 @@ This is some sample code:
                 resultCode = await VerifyCommand.Do(
                                      new VerifyOptions(rootDirectory),
                                      console,
-                                     () => directoryAccessor,
-                                     packageRegistry);
+                                     (dir) => directoryAccessor);
 
                 _output.WriteLine(console.Out.ToString());
 
@@ -718,8 +699,7 @@ Console.WriteLine(""code"");
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root),
+                    (dir) => directoryAccessor,
                     new StartupOptions(package: project.FullName));
 
                 _output.WriteLine(console.Out.ToString());
@@ -756,8 +736,7 @@ public class EmptyClassTwo {{}}
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root),
+                    (dir) => directoryAccessor,
                     new StartupOptions(package: project.FullName)
                     );
 
@@ -794,8 +773,7 @@ public class EmptyClassTwo {{
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root),
+                    (dir) => directoryAccessor,
                     new StartupOptions(package: project.FullName));
 
                 _output.WriteLine(console.Out.ToString());
@@ -827,8 +805,7 @@ Console.WriteLine(""This code should be compiled with the targetRegion in Progra
                 var resultCode = await VerifyCommand.Do(
                     new VerifyOptions(root),
                     console,
-                    () => directoryAccessor,
-                    PackageRegistry.CreateForTryMode(root),
+                    (dir) => directoryAccessor,
                     new StartupOptions(package: project.FullName)
                     );
 

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -96,8 +96,7 @@ namespace MLS.Agent.CommandLine
                      ((verifyOptions, console, startupOptions) =>
                              VerifyCommand.Do(verifyOptions,
                                               console,
-                                              () => new FileSystemDirectoryAccessor(verifyOptions.Dir),
-                                              PackageRegistry.CreateForTryMode(verifyOptions.Dir),
+                                              (dir) => new FileSystemDirectoryAccessor(dir),
                                               startupOptions));
 
             pack = pack ??
@@ -113,7 +112,7 @@ namespace MLS.Agent.CommandLine
             {
                 Arity = ArgumentArity.ZeroOrOne,
                 Name = nameof(StartupOptions.Dir).ToLower(),
-                Description = "Specify the path to the root directory for your documentation"
+                Description = "Specify the path to the root directory for your documentation",
             }.ExistingOnly();
 
             var rootCommand = StartInTryMode();

--- a/MLS.Agent/CommandLine/VerifyCommand.cs
+++ b/MLS.Agent/CommandLine/VerifyCommand.cs
@@ -23,11 +23,11 @@ namespace MLS.Agent.CommandLine
         public static async Task<int> Do(
             VerifyOptions options,
             IConsole console,
-            Func<IDirectoryAccessor> getDirectoryAccessor,
-            PackageRegistry packageRegistry,
+            Func<DirectoryInfo, IDirectoryAccessor> getDirectoryAccessor,
             StartupOptions startupOptions = null)
         {
-            var directoryAccessor = getDirectoryAccessor();
+            var packageRegistry = PackageRegistry.CreateForTryMode(options.Dir);
+            var directoryAccessor = getDirectoryAccessor(options.Dir);
             var markdownProject = new MarkdownProject(
                 directoryAccessor,
                 packageRegistry,

--- a/MLS.Agent/CommandLine/VerifyOptions.cs
+++ b/MLS.Agent/CommandLine/VerifyOptions.cs
@@ -9,7 +9,7 @@ namespace MLS.Agent.CommandLine
     {
         public VerifyOptions(DirectoryInfo dir)
         {
-            Dir = dir;
+            Dir = dir ?? new DirectoryInfo(Directory.GetCurrentDirectory());
         }
 
         public DirectoryInfo Dir { get; }

--- a/Microsoft.DotNet.Try.ProjectTemplate.Tests/TutorialTemplateTests.cs
+++ b/Microsoft.DotNet.Try.ProjectTemplate.Tests/TutorialTemplateTests.cs
@@ -46,13 +46,11 @@ namespace Microsoft.DotNet.Try.ProjectTemplate.Tests
             //The template targets 3.0 hence verify should run against 3.0 and not 2.1.503 used in the solution directory
             await dotnet.New("global.json", "--sdk-version 3.0.100-preview6-012264");
             var console = new TestConsole();
-            var directoryAccessor = new FileSystemDirectoryAccessor(outputDirectory);
 
             var resultCode = await VerifyCommand.Do(
                 new VerifyOptions(outputDirectory),
                 console,
-                () => directoryAccessor,
-                PackageRegistry.CreateForTryMode(outputDirectory));
+                (dir) =>  new FileSystemDirectoryAccessor(dir));
 
             console.Out
                        .ToString()


### PR DESCRIPTION
1. If no directory has been speicified verify should take the current directory in the VerifyOptions
2. The directory from the VerifyOptions must be used inside the VerifyCommand to create a package registry and get a directory accessor, so that it is ensured that all operations are performed with respect to the dir passed in the verify options