### PR TITLE
fix #377

### DIFF
--- a/Microsoft.DotNet.Interactive.Rendering.Tests/PlainTextFormatterTests.cs
+++ b/Microsoft.DotNet.Interactive.Rendering.Tests/PlainTextFormatterTests.cs
@@ -65,6 +65,26 @@ namespace Microsoft.DotNet.Interactive.Rendering.Tests
                 ex.Message.Should().Contain("o => o.DateProperty.ToShortDateString()");
             }
 
+            [Theory]
+            [InlineData(typeof(Boolean), "False")]
+            [InlineData(typeof(Byte), "0")]
+            [InlineData(typeof(Decimal), "0")]
+            [InlineData(typeof(Double), "0")]
+            [InlineData(typeof(Guid), "00000000-0000-0000-0000-000000000000")]
+            [InlineData(typeof(Int16), "0")]
+            [InlineData(typeof(Int32), "0")]
+            [InlineData(typeof(Int64), "0")]
+            [InlineData(typeof(Single), "0")]
+            [InlineData(typeof(UInt16), "0")]
+            [InlineData(typeof(UInt32), "0")]
+            [InlineData(typeof(UInt64), "0")]
+            public void It_does_not_expand_properties_of_scalar_types(Type type, string expected)
+            {
+                var value = Activator.CreateInstance(type);
+
+                value.ToDisplayString().Should().Be(expected);
+            }
+
             [Fact]
             public void It_expands_properties_of_structs()
             {

--- a/Microsoft.DotNet.Interactive.Rendering/Formatter.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/Formatter.cs
@@ -261,9 +261,6 @@ namespace Microsoft.DotNet.Interactive.Rendering
             Action<object, TextWriter> formatter,
             string mimeType = Rendering.PlainTextFormatter.MimeType)
         {
-
-
-
             var delegateType = typeof(Action<,>).MakeGenericType(type, typeof(TextWriter));
 
             var genericRegisterMethod = typeof(Formatter<>)

--- a/Microsoft.DotNet.Interactive.Rendering/Formatter{T}.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/Formatter{T}.cs
@@ -118,11 +118,9 @@ namespace Microsoft.DotNet.Interactive.Rendering
             switch (mimeType)
             {
                 case "text/html":
-
                     return HtmlFormatter<T>.Create();
 
                 default:
-
                     return PlainTextFormatter<T>.Create();
             }
         }

--- a/Microsoft.DotNet.Interactive.Rendering/PlainTextFormatter.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/PlainTextFormatter.cs
@@ -196,8 +196,6 @@ namespace Microsoft.DotNet.Interactive.Rendering
                 pair.Value.FormatTo(writer);
             }),
 
-            [typeof(string)] = new PlainTextFormatter<string>((s, writer) => writer.Write(s)),
-
             [typeof(Type)] = new PlainTextFormatter<Type>((type, writer) =>
             {
                 var typeName = type.Name;
@@ -224,15 +222,6 @@ namespace Microsoft.DotNet.Interactive.Rendering
                 }
             }),
 
-            [typeof(bool)] = new PlainTextFormatter<bool>((value, writer) => writer.Write(value)),
-            [typeof(byte)] = new PlainTextFormatter<byte>((value, writer) => writer.Write(value)),
-            [typeof(short)] = new PlainTextFormatter<short>((value, writer) => writer.Write(value)),
-            [typeof(int)] = new PlainTextFormatter<int>((value, writer) => writer.Write(value)),
-            [typeof(long)] = new PlainTextFormatter<long>((value, writer) => writer.Write(value)),
-            [typeof(Guid)] = new PlainTextFormatter<Guid>((value, writer) => writer.Write(value)),
-            [typeof(decimal)] = new PlainTextFormatter<decimal>((value, writer) => writer.Write(value)),
-            [typeof(float)] = new PlainTextFormatter<float>((value, writer) => writer.Write(value)),
-            [typeof(double)] = new PlainTextFormatter<double>((value, writer) => writer.Write(value)),
             [typeof(DateTime)] = new PlainTextFormatter<DateTime>((value, writer) => writer.Write(value.ToString("u"))),
             [typeof(DateTimeOffset)] = new PlainTextFormatter<DateTimeOffset>((value, writer) => writer.Write(value.ToString("u"))),
         };

--- a/Microsoft.DotNet.Interactive.Rendering/PlainTextFormatter{T}.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/PlainTextFormatter{T}.cs
@@ -51,6 +51,11 @@ namespace Microsoft.DotNet.Interactive.Rendering
 
         private static PlainTextFormatter<T> CreateForAllMembers(bool includeInternals = false)
         {
+            if (typeof(T).IsScalar())
+            {
+                return new PlainTextFormatter<T>((value, writer) => writer.Write(value));
+            }
+
             return new PlainTextFormatter<T>(
                 PlainTextFormatter.CreateFormatDelegate<T>(
                     typeof(T).GetAllMembers(includeInternals).ToArray()));

--- a/Microsoft.DotNet.Interactive.Rendering/TypeExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/TypeExtensions.cs
@@ -89,12 +89,24 @@ namespace Microsoft.DotNet.Interactive.Rendering
                    (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;
         }
 
+        private static readonly HashSet<Type> _knownScalarTypes = new HashSet<Type>
+        {
+            typeof(decimal),
+            typeof(Guid),
+            typeof(string),
+        };
+
         public static bool IsScalar(this Type type)
         {
+            if (_knownScalarTypes.Contains(type))
+            {
+                return true;
+            }
+
             return type.IsPrimitive ||
-                   type == typeof(string) ||
                    (type.IsConstructedGenericType &&
-                    type.GetGenericTypeDefinition() == typeof(Nullable<>));
+                    type.GetGenericTypeDefinition() == typeof(Nullable<>) && 
+                    type.GetGenericArguments()[0].IsScalar());
         }
 
         public static bool IsValueTuple(this Type type)


### PR DESCRIPTION
This slightly cleans up the approach to specifying which types shouldn't be formatted property-by-property. It fixes #377.