### PR TITLE
update FSharpKernel to use FSharp.Compiler.Scripting

### DIFF
--- a/FSharpWorkspaceShim/FSharpWorkspaceShim.fsproj
+++ b/FSharpWorkspaceShim/FSharpWorkspaceShim.fsproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="FSharp.Core" Version="4.6.3-beta.19425.1" />
     <PackageReference Include="FSharp.Compiler.Service" Version="28.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.1.0-beta3-final" />
   </ItemGroup>

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -3,70 +3,35 @@
 
 namespace Microsoft.DotNet.Interactive.FSharp
 
-open System
-open System.ComponentModel
-open System.Diagnostics
-open System.Text
 open System.Threading.Tasks
+open FSharp.Compiler.Scripting
 open Microsoft.DotNet.Interactive
 open Microsoft.DotNet.Interactive.Commands
 open Microsoft.DotNet.Interactive.Events
-open MLS.Agent.Tools
 
 type FSharpKernel() =
     inherit KernelBase()
-    let mutable proc: Process = null
-    let write (s: string) = proc.StandardInput.Write(s)
-    let sentinelValue = Guid.NewGuid().ToString()
-    let sentinelFound = Event<_>()
-    let stdout = StringBuilder()
-    let waitForReady () =
-        async {
-            write <| sprintf ";;printfn \"\\n%s\";;\n" sentinelValue
-            do! Async.AwaitEvent sentinelFound.Publish
-        }
-    let startProcess () =
-        async {
-            if isNull proc then
-                let outputReceived line =
-                    if line = sentinelValue then
-                        sentinelFound.Trigger()
-                    else
-                        stdout.AppendLine(line) |> ignore
-                proc <- Dotnet().StartProcess("fsi --nologo", output = Action<string>(outputReceived))
-                do! waitForReady()
-        }
-    let eval (code: string) =
-        async {
-            do! startProcess ()
-            stdout.Clear() |> ignore
-            write code
-            do! waitForReady ()
-            let value = stdout.ToString()
-            // trim garbage
-            let nl = Environment.NewLine
-            let headerGarbage = sprintf "val it : unit = ()%s%s" nl nl
-            let value =  if value.StartsWith(headerGarbage) then value.Substring(headerGarbage.Length) else value
-            let footerGarbage = sprintf "%s%s> %s" nl nl nl
-            let value = if value.EndsWith(footerGarbage) then value.Substring(0, value.Length - footerGarbage.Length) else value
-            return value
-        }
-    do base.AddDisposable({ new IDisposable with
-                                member __.Dispose() =
-                                    if not <| isNull proc then
-                                        try
-                                            proc.Kill()
-                                        with
-                                        | :? InvalidOperationException -> ()
-                                        | :? NotSupportedException -> ()
-                                        | :? Win32Exception -> () })
+    let script = new FSharpScript()
+    do base.AddDisposable(script)
     let handleSubmitCode (codeSubmission: SubmitCode) (context: KernelInvocationContext) =
         async {
             let codeSubmissionReceived = CodeSubmissionReceived(codeSubmission.Code, codeSubmission)
             context.OnNext(codeSubmissionReceived)
-            // submit code
-            let! value = eval codeSubmission.Code
-            context.OnNext(ValueProduced(value, codeSubmission, true, [FormattedValue("text/plain", value)]))
+            let result, errors =
+                try
+                    script.Eval(codeSubmission.Code)
+                with
+                | ex -> Error(ex), [||]
+            if errors.Length > 0 then
+                let aggregateErrorMessage = System.String.Join("\n", errors)
+                context.OnNext(CodeSubmissionEvaluationFailed(aggregateErrorMessage, codeSubmission))
+            match result with
+            | Ok(Some(value)) ->
+                let value = value.ReflectionValue
+                let formattedValues = FormattedValue.FromObject(value)
+                context.OnNext(ValueProduced(value, codeSubmission, true, formattedValues))
+            | Ok(None) -> ()
+            | Error(ex) -> context.OnError(ex)
             context.OnNext(CodeSubmissionEvaluated(codeSubmission))
             context.OnCompleted()
         }

--- a/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -21,7 +21,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Interactive\Microsoft.DotNet.Interactive.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Interactive.Rendering\Microsoft.DotNet.Interactive.Rendering.csproj" />
     <ProjectReference Include="..\MLS.Agent.Tools\MLS.Agent.Tools.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Compiler.Private.Scripting" Version="10.5.0-beta.19425.1" />
+    <PackageReference Include="FSharp.Core" Version="4.6.3-beta.19425.1" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -208,19 +208,20 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
         private void OnCodeSubmissionEvaluated(CodeSubmissionEvaluated codeSubmissionEvaluated)
         {
-            InFlightRequests.TryRemove(codeSubmissionEvaluated.Command, out var openRequest);
+            if (InFlightRequests.TryRemove(codeSubmissionEvaluated.Command, out var openRequest))
+            {
+                // reply ok
+                var executeReplyPayload = new ExecuteReplyOk(executionCount: openRequest.ExecutionCount);
 
-            // reply ok
-            var executeReplyPayload = new ExecuteReplyOk(executionCount: openRequest.ExecutionCount);
+                // send to server
+                var executeReply = Message.CreateResponse(
+                    executeReplyPayload,
+                    openRequest.Context.Request);
 
-            // send to server
-            var executeReply = Message.CreateResponse(
-                executeReplyPayload,
-                openRequest.Context.Request);
-
-            openRequest.Context.ServerChannel.Send(executeReply);
-            openRequest.Context.RequestHandlerStatus.SetAsIdle();
-            openRequest.Dispose();
+                openRequest.Context.ServerChannel.Send(executeReply);
+                openRequest.Context.RequestHandlerStatus.SetAsIdle();
+                openRequest.Dispose();
+            }
         }
     }
 }

--- a/Microsoft.DotNet.Interactive.Rendering/Formatter.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/Formatter.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Interactive.Rendering
         }
 
         public static string ToDisplayString(
-            this object obj, 
+            this object obj,
             string mimeType = Rendering.PlainTextFormatter.MimeType)
         {
             // TODO: (ToDisplayString) rename
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Interactive.Rendering
         }
 
         public static void FormatTo<T>(
-            this T obj, 
+            this T obj,
             TextWriter writer,
             string mimeType = Rendering.PlainTextFormatter.MimeType)
         {
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.Interactive.Rendering
             var writerParam = Expression.Parameter(typeof(TextWriter), "target");
             var mimeTypeParam = Expression.Parameter(typeof(string), "target");
 
-            var methodCallExpr = Expression.Call(null, 
+            var methodCallExpr = Expression.Call(null,
                                                  methodInfo,
                                                  Expression.Convert(targetParam, type),
                                                  writerParam,

--- a/Microsoft.DotNet.Interactive/Events/CodeSubmissionEvaluationFailed.cs
+++ b/Microsoft.DotNet.Interactive/Events/CodeSubmissionEvaluationFailed.cs
@@ -19,6 +19,12 @@ namespace Microsoft.DotNet.Interactive.Events
                           : message;
         }
 
+        public CodeSubmissionEvaluationFailed(
+            string message,
+            SubmitCode submitCode) : this(null, message, submitCode)
+        {
+        }
+
         public string Code => ((SubmitCode)Command).Code;
 
         public Exception Exception { get; }

--- a/Microsoft.DotNet.Interactive/FormattedValue.cs
+++ b/Microsoft.DotNet.Interactive/FormattedValue.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Interactive.Rendering;
 
 namespace Microsoft.DotNet.Interactive
 {
@@ -21,5 +23,27 @@ namespace Microsoft.DotNet.Interactive
         public string MimeType { get; }
 
         public object Value { get; }
+
+        public static IReadOnlyCollection<FormattedValue> FromObject(object value)
+        {
+            var type = value?.GetType();
+
+            var mimeType = MimeTypeFor(type);
+
+            var formatted = value.ToDisplayString(mimeType);
+
+            return new FormattedValue[]
+            {
+                new FormattedValue(mimeType, formatted)
+            };
+        }
+
+        private static string MimeTypeFor(Type returnValueType)
+        {
+            return returnValueType?.IsPrimitive == true ||
+                   returnValueType == typeof(string)
+                       ? "text/plain"
+                       : "text/html";
+        }
     }
 }

--- a/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -127,7 +127,9 @@ namespace Microsoft.DotNet.Interactive
 
                 var parseResult = BuildDirectiveParser().Parse(currentLine);
 
-                if (parseResult.Errors.Count == 0)
+                if (parseResult.Errors.Count == 0 &&
+                    !parseResult.Directives.Any() && // System.CommandLine directives should not be considered as valid
+                    !parseResult.Tokens.Any(t => t.Type == TokenType.Directive))
                 {
                     modified = true;
                     await _directiveParser.InvokeAsync(parseResult);

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-fsharp" value="https://dotnet.myget.org/F/fsharp/api/v3/index.json" />
     <add key="dotnet-try" value="https://dotnet.myget.org/F/dotnet-try/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/WorkspaceServer.Tests/Kernel/FSharpKernelTests.cs
+++ b/WorkspaceServer.Tests/Kernel/FSharpKernelTests.cs
@@ -31,7 +31,7 @@ namespace WorkspaceServer.Tests.Kernel
         {
             var kernel = CreateKernel();
             await kernel.SendAsync(new SubmitCode("123"));
-            AssertLastValue("> val it : int = 123");
+            AssertLastValue(123);
         }
 
         [Fact]
@@ -39,12 +39,22 @@ namespace WorkspaceServer.Tests.Kernel
         {
             var kernel = CreateKernel();
             await kernel.SendAsync(new SubmitCode("let add x y = x + y"));
-            AssertLastValue("> val add : x:int -> y:int -> int");
             await kernel.SendAsync(new SubmitCode("add 2 3"));
-            AssertLastValue("> val it : int = 5");
+            AssertLastValue(5);
         }
 
-        private void AssertLastValue(string value)
+        [Fact]
+        public async Task kernel_base_ignores_command_line_directives()
+        {
+            // The text `[1;2;3;4]` parses as a System.CommandLine directive; ensure it's not consumed and is passed on to the kernel.
+            var kernel = CreateKernel();
+            await kernel.SendAsync(new SubmitCode(@"
+[1;2;3;4]
+|> List.sum"));
+            AssertLastValue(10);
+        }
+
+        private void AssertLastValue(object value)
         {
             KernelEvents.ValuesOnly()
                 .OfType<ValueProduced>()

--- a/WorkspaceServer/Kernel/CSharpKernel.cs
+++ b/WorkspaceServer/Kernel/CSharpKernel.cs
@@ -142,17 +142,7 @@ namespace WorkspaceServer.Kernel
             {
                 if (HasReturnValue)
                 {
-                    var returnValueType = _scriptState.ReturnValue?.GetType();
-
-                    var mimeType = MimeTypeFor(returnValueType);
-
-                    var formatted = _scriptState.ReturnValue.ToDisplayString(mimeType);
-
-                    var formattedValues = new List<FormattedValue>
-                        {
-                            new FormattedValue(mimeType, formatted)
-                        };
-
+                    var formattedValues = FormattedValue.FromObject(_scriptState.ReturnValue);
                     context.OnNext(
                         new ValueProduced(
                             _scriptState.ReturnValue,
@@ -165,14 +155,6 @@ namespace WorkspaceServer.Kernel
 
                 context.OnCompleted();
             }
-        }
-
-        private static string MimeTypeFor(Type returnValueType)
-        {
-            return returnValueType?.IsPrimitive == true ||
-                   returnValueType == typeof(string)
-                       ? "text/plain"
-                       : "text/html";
         }
 
         private void PublishOutput(

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,6 +43,7 @@
       $(RestoreSources);
       https://dotnet.myget.org/F/dotnet-try/api/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      https://dotnet.myget.org/F/fsharp/api/v3/index.json
     </RestoreSources>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This allows us to return proper `System.Object`s which means we get the default formatting for `IEnumerable<T>`.

![image](https://user-images.githubusercontent.com/926281/63728190-a3d59f80-c817-11e9-9147-95f5cf2f2edb.png)

This included an interesting bug where the directive/magic preprocessor will accept a left bracket followed by any non-whitespace characters then a right bracket bracket (e.g., `\[[^\s]+\]`) and return those as a `System.CommandLine` directive, which is exactly what we don't want for F# where `[1;2;3;4]` is a valid `List<'t>`.  To get around that I added some checks to ensure that the magic string parser ignores directives.  I also filed dotnet/command-line-api#625 to track future work.

Still to figure out: how to consume the helper functions/formatters.  E.g., `a[href: "some-url"]("click me")` won't work in F# like it does in C#.
