### PR TITLE
fix display functionality

### DIFF
--- a/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
         private void OnCommandFailed(CommandFailed commandFailed)
         {
-            if (!InFlightRequests.TryRemove(commandFailed.Command, out var openRequest))
+            if (!InFlightRequests.TryRemove(commandFailed.GetRootCommand(), out var openRequest))
             {
                 return;
             }
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
         private void OnValueProductionEvent(ValueProducedEventBase eventBase)
         {
-            if (!InFlightRequests.TryGetValue(eventBase.Command, out var openRequest))
+            if (!InFlightRequests.TryGetValue(eventBase.GetRootCommand(), out var openRequest))
             {
                 return;
             }
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
         private void OnCodeSubmissionEvaluated(CodeSubmissionEvaluated codeSubmissionEvaluated)
         {
-            if (!InFlightRequests.TryRemove(codeSubmissionEvaluated.Command, out var openRequest))
+            if (!InFlightRequests.TryRemove(codeSubmissionEvaluated.GetRootCommand(), out var openRequest))
             {
                 return;
             }

--- a/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
@@ -106,7 +105,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
 
                     supportedDirectives.Commands.AddRange(context.CurrentKernel.Directives);
 
-                    context.Publish(new Events.DisplayedValueProduced(supportedDirectives));
+                    context.Publish(new DisplayedValueProduced(supportedDirectives, context.Command));
 
                     await context.CurrentKernel.VisitSubkernelsAsync(async k =>
                     {

--- a/Microsoft.DotNet.Interactive/Commands/KernelCommandBase.cs
+++ b/Microsoft.DotNet.Interactive/Commands/KernelCommandBase.cs
@@ -12,6 +12,15 @@ namespace Microsoft.DotNet.Interactive.Commands
         [JsonIgnore]
         public KernelCommandInvocation Handler { get; set; }
 
+        [JsonIgnore]
+        public IKernelCommand Parent { get; }
+
+        protected KernelCommandBase()
+        {
+            Parent = KernelInvocationContext.Current?.Command;
+        }
+        
+
         public async Task InvokeAsync(KernelInvocationContext context)
         {
             if (Handler == null)

--- a/Microsoft.DotNet.Interactive/Events/DisplayedValueProduced.cs
+++ b/Microsoft.DotNet.Interactive/Events/DisplayedValueProduced.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Interactive.Events
     {
         public DisplayedValueProduced(
             object value,
-            IKernelCommand command = null,
+            IKernelCommand command,
             IReadOnlyCollection<FormattedValue> formattedValues = null,
             string valueId = null) : base(value, command,formattedValues, valueId)
         {

--- a/Microsoft.DotNet.Interactive/Events/IKernelEvent.cs
+++ b/Microsoft.DotNet.Interactive/Events/IKernelEvent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.Events
@@ -9,5 +10,26 @@ namespace Microsoft.DotNet.Interactive.Events
     {
 
         IKernelCommand Command { get; }
+    }
+
+    public static class KernelEventExtensions
+    {
+        public static IKernelCommand GetRootCommand(this IKernelEvent kernelEvent)
+        {
+            if (kernelEvent == null)
+            {
+                throw new ArgumentNullException(nameof(kernelEvent));
+            }
+
+            var root = kernelEvent.Command as KernelCommandBase;
+
+            while (root?.Parent != null)
+            {
+                root = root.Parent as KernelCommandBase;
+            }
+
+
+            return root;
+        }
     }
 }

--- a/Microsoft.DotNet.Interactive/Events/IKernelEvent.cs
+++ b/Microsoft.DotNet.Interactive/Events/IKernelEvent.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.Events
@@ -10,26 +9,5 @@ namespace Microsoft.DotNet.Interactive.Events
     {
 
         IKernelCommand Command { get; }
-    }
-
-    public static class KernelEventExtensions
-    {
-        public static IKernelCommand GetRootCommand(this IKernelEvent kernelEvent)
-        {
-            if (kernelEvent == null)
-            {
-                throw new ArgumentNullException(nameof(kernelEvent));
-            }
-
-            var root = kernelEvent.Command as KernelCommandBase;
-
-            while (root?.Parent != null)
-            {
-                root = root.Parent as KernelCommandBase;
-            }
-
-
-            return root;
-        }
     }
 }

--- a/Microsoft.DotNet.Interactive/Events/KernelEventExtensions.cs
+++ b/Microsoft.DotNet.Interactive/Events/KernelEventExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Interactive.Commands;
+
+namespace Microsoft.DotNet.Interactive.Events
+{
+    public static class KernelEventExtensions
+    {
+        public static IKernelCommand GetRootCommand(this IKernelEvent kernelEvent)
+        {
+            if (kernelEvent == null)
+            {
+                throw new ArgumentNullException(nameof(kernelEvent));
+            }
+
+            var root = kernelEvent.Command;
+
+            while (root is KernelCommandBase kb &&  kb.Parent != null)
+            {
+                root = kb.Parent;
+            }
+
+            return root;
+        }
+    }
+}

--- a/Microsoft.DotNet.Interactive/Events/ValueProducedEventBase.cs
+++ b/Microsoft.DotNet.Interactive/Events/ValueProducedEventBase.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Interactive.Events
     {
         protected ValueProducedEventBase(
             object value,
-            IKernelCommand command = null,
+            IKernelCommand command,
             IReadOnlyCollection<FormattedValue> formattedValues = null,
             string valueId = null) : base(command)
         {


### PR DESCRIPTION
nested events from child commands need to be able to trace the path to the original root command