### PR TITLE
Pipeline fixes and script state access

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,7 +3,7 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(DisableArcade)' != '1'" />
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests')) AND '$(DisableArcade)' == '1'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/MLS.Agent/NativeAssemblyLoadHelper.cs
+++ b/MLS.Agent/NativeAssemblyLoadHelper.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
-using static WorkspaceServer.Kernel.CSharpKernelExtensions;
+using WorkspaceServer.Kernel;
 
 namespace MLS.Agent
 {

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -32,7 +32,7 @@ type FSharpKernel() =
                 context.Publish(ReturnValueProduced(value, codeSubmission, formattedValues))
             | Ok(None) -> ()
             | Error(ex) -> context.OnError(ex)
-            context.Publish(CodeSubmissionEvaluated(codeSubmission))
+            context.Publish(CommandHandled(codeSubmission))
             context.Complete()
         }
 

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -33,14 +33,12 @@ type FSharpKernel() =
             | Ok(None) -> ()
             | Error(ex) -> context.OnError(ex)
             context.Publish(CommandHandled(codeSubmission))
-            context.Complete()
         }
 
     let handleCancelCurrentCommand (cancelCurrentCommand: CancelCurrentCommand) (context: KernelInvocationContext) =
         async {
             let reply = CurrentCommandCancelled(cancelCurrentCommand)           
             context.Publish(reply)
-            context.Complete()
         }
 
     override __.HandleAsync(command: IKernelCommand, _context: KernelInvocationContext): Task =

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
         }
 
         [Fact]
-        public async Task sends_ExecuteReply_message_on_CodeSubmissionEvaluated()
+        public async Task sends_ExecuteReply_message_on_when_code_submission_is_handled()
         {
             var kernel = new CSharpKernel();
 
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
         }
 
         [Fact]
-        public async Task sends_ExecuteReply_with_error_message_on_CodeSubmissionEvaluated()
+        public async Task sends_ExecuteReply_with_error_message_on_when_code_submission_contains_errors()
         {
             var kernel = new CSharpKernel();
 

--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.DotNet.Interactive.FSharp;
 using Microsoft.DotNet.Interactive.Jupyter.Protocol;
 using WorkspaceServer.Kernel;
 using Xunit;
@@ -123,7 +124,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
             var kernel = new CompositeKernel
             {
                 new CSharpKernel()
-            };
+            }.UseDefaultMagicCommands();
 
             var handler = new ExecuteRequestHandler(kernel);
             var request = Message.Create(new ExecuteRequest("%%csharp"), null);

--- a/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                 case ValueProducedEventBase valueProductionEvent:
                     OnValueProductionEvent(valueProductionEvent);
                     break;
-                case CodeSubmissionEvaluated codeSubmissionEvaluated:
+                case CommandHandled codeSubmissionEvaluated:
                     OnCodeSubmissionEvaluated(codeSubmissionEvaluated);
                     break;
                 case CommandFailed codeSubmissionEvaluationFailed:
@@ -180,9 +180,9 @@ namespace Microsoft.DotNet.Interactive.Jupyter
             }
         }
 
-        private void OnCodeSubmissionEvaluated(CodeSubmissionEvaluated codeSubmissionEvaluated)
+        private void OnCodeSubmissionEvaluated(CommandHandled commandHandled)
         {
-            if (!InFlightRequests.TryRemove(codeSubmissionEvaluated.GetRootCommand(), out var openRequest))
+            if (!InFlightRequests.TryRemove(commandHandled.GetRootCommand(), out var openRequest))
             {
                 return;
             }

--- a/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -59,11 +59,11 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                 case ValueProducedEventBase valueProductionEvent:
                     OnValueProductionEvent(valueProductionEvent);
                     break;
-                case CommandHandled codeSubmissionEvaluated:
-                    OnCodeSubmissionEvaluated(codeSubmissionEvaluated);
+                case CommandHandled commandHandled:
+                    OnCommandHandled(commandHandled);
                     break;
-                case CommandFailed codeSubmissionEvaluationFailed:
-                    OnCommandFailed(codeSubmissionEvaluationFailed);
+                case CommandFailed commandFailed:
+                    OnCommandFailed(commandFailed);
                     break;
                 case CodeSubmissionReceived _:
                 case IncompleteCodeSubmissionReceived _:
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter
             }
         }
 
-        private void OnCodeSubmissionEvaluated(CommandHandled commandHandled)
+        private void OnCommandHandled(CommandHandled commandHandled)
         {
             if (!InFlightRequests.TryRemove(commandHandled.GetRootCommand(), out var openRequest))
             {

--- a/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
@@ -202,17 +201,5 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                 })
             };
         }
-    }
-
-    public class SupportedDirectives
-    {
-        public string KernelName { get; }
-
-        public SupportedDirectives(string kernelName)
-        {
-            KernelName = kernelName;
-        }
-
-        public List<ICommand> Commands { get; } = new List<ICommand>();
     }
 }

--- a/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
@@ -51,8 +51,6 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                                            {
                                                new FormattedValue("text/html", htmlContent)
                                            }));
-                        
-                        context.Complete();
                     }
                 })
             });
@@ -100,8 +98,6 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                                 {
                                     new FormattedValue("text/html", html)
                                 }));
-
-                        context.Complete();
                     }
                 })
             });
@@ -196,7 +192,6 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                                                new FormattedValue("text/html",
                                                                   value)
                                            }));
-                        context.Complete();
                     }
                 })
             };

--- a/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/KernelExtensions.cs
@@ -42,7 +42,6 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                         var htmlContent = submitCode.Code
                                                       .Replace("%%html", "")
                                                       .Trim();
-
                       
                         context.Publish(new DisplayedValueProduced(
                                            htmlContent,
@@ -51,6 +50,8 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                                            {
                                                new FormattedValue("text/html", htmlContent)
                                            }));
+
+                        context.Complete();
                     }
                 })
             });
@@ -98,6 +99,8 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                                 {
                                     new FormattedValue("text/html", html)
                                 }));
+
+                        context.Complete();
                     }
                 })
             });
@@ -192,6 +195,8 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                                                new FormattedValue("text/html",
                                                                   value)
                                            }));
+
+                        context.Complete();
                     }
                 })
             };

--- a/Microsoft.DotNet.Interactive.Jupyter/SupportedDirectives.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/SupportedDirectives.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.CommandLine;
+
+namespace Microsoft.DotNet.Interactive.Jupyter
+{
+    public class SupportedDirectives
+    {
+        public string KernelName { get; }
+
+        public SupportedDirectives(string kernelName)
+        {
+            KernelName = kernelName;
+        }
+
+        public List<ICommand> Commands { get; } = new List<ICommand>();
+    }
+}

--- a/Microsoft.DotNet.Interactive/Commands/KernelCommandBase.cs
+++ b/Microsoft.DotNet.Interactive/Commands/KernelCommandBase.cs
@@ -19,7 +19,6 @@ namespace Microsoft.DotNet.Interactive.Commands
         {
             Parent = KernelInvocationContext.Current?.Command;
         }
-        
 
         public async Task InvokeAsync(KernelInvocationContext context)
         {

--- a/Microsoft.DotNet.Interactive/Commands/LoadExtensionFromNuGetPackage.cs
+++ b/Microsoft.DotNet.Interactive/Commands/LoadExtensionFromNuGetPackage.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Interactive.Commands
 {
@@ -16,7 +16,10 @@ namespace Microsoft.DotNet.Interactive.Commands
             MetadataReferences = metadataReferences ?? throw new ArgumentNullException(nameof(metadataReferences));
         }
 
+        [JsonIgnore]
         public NugetPackageReference NugetPackageReference { get; }
+
+        [JsonIgnore]
         public IEnumerable<FileInfo> MetadataReferences { get; }
     }
 }

--- a/Microsoft.DotNet.Interactive/CompositeKernel.cs
+++ b/Microsoft.DotNet.Interactive/CompositeKernel.cs
@@ -94,6 +94,11 @@ namespace Microsoft.DotNet.Interactive
             throw new NoSuitableKernelException();
         }
 
+        internal override Task HandleInternalAsync(IKernelCommand command, KernelInvocationContext context)
+        {
+            return HandleAsync(command, context);
+        }
+
         public IReadOnlyCollection<IKernel> ChildKernels => _childKernels;
 
         public IEnumerator<IKernel> GetEnumerator() => _childKernels.GetEnumerator();

--- a/Microsoft.DotNet.Interactive/Events/CommandHandled.cs
+++ b/Microsoft.DotNet.Interactive/Events/CommandHandled.cs
@@ -5,14 +5,10 @@ using Microsoft.DotNet.Interactive.Commands;
 
 namespace Microsoft.DotNet.Interactive.Events
 {
-    public class CodeSubmissionEvaluated : KernelEventBase
+    public class CommandHandled : KernelEventBase
     {
-        public CodeSubmissionEvaluated(SubmitCode command) : base(command)
+        public CommandHandled(IKernelCommand command) : base(command)
         {
         }
-
-        public string Code => ((SubmitCode) Command).Code;
-
-        public override string ToString() => $"{base.ToString()}: {Code.TruncateForDisplay()}";
     }
 }

--- a/Microsoft.DotNet.Interactive/IKernel.cs
+++ b/Microsoft.DotNet.Interactive/IKernel.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
-using MLS.Agent.Tools;
 
 namespace Microsoft.DotNet.Interactive
 {

--- a/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -112,8 +112,6 @@ namespace Microsoft.DotNet.Interactive
                 {
                     context.Publish(new CommandFailed($"Kernel {invocationContext.HandlingKernel.Name} doesn't support loading extensions", loadExtensionFromNuGetPackage));
                 }
-
-                context.Complete();
             };
 
             await Task.CompletedTask;
@@ -128,7 +126,6 @@ namespace Microsoft.DotNet.Interactive
             {
                 var kernelextensionLoader = new KernelExtensionLoader();
                 await kernelextensionLoader.LoadFromAssembly(loadExtension.AssemblyFile, invocationContext.HandlingKernel, (kernelEvent) => context.Publish(kernelEvent));
-                context.Complete();
             };
 
             await next(loadExtension, invocationContext);
@@ -147,7 +144,7 @@ namespace Microsoft.DotNet.Interactive
 
             var unhandledLines = new List<string>();
 
-            while (lines.Count > 0 && !pipelineContext.IsCompleted)
+            while (lines.Count > 0)
             {
                 var currentLine = lines.Dequeue();
 
@@ -197,8 +194,6 @@ namespace Microsoft.DotNet.Interactive
                         formattedValues: new[] { displayValue.FormattedValue },
                         valueId: displayValue.ValueId));
 
-                invocationContext.Complete();
-
                 return Task.CompletedTask;
             };
 
@@ -219,8 +214,6 @@ namespace Microsoft.DotNet.Interactive
                         command: displayedValue,
                         formattedValues: new[] { displayedValue.FormattedValue }
                         ));
-
-                invocationContext.Complete();
 
                 return Task.CompletedTask;
             };
@@ -297,7 +290,6 @@ namespace Microsoft.DotNet.Interactive
                 {
                     result = new KernelCommandResult(KernelEvents);
                     context.Publish(new CommandHandled(context.Command));
-                    context.Complete();
                 }
 
                 operation.TaskCompletionSource.SetResult(result);

--- a/Microsoft.DotNet.Interactive/KernelCommandPipeline.cs
+++ b/Microsoft.DotNet.Interactive/KernelCommandPipeline.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Interactive
             }
         }
 
-        public async Task SendAsync(
+        internal async Task SendAsync(
             IKernelCommand command,
             KernelInvocationContext context)
         {
@@ -56,7 +56,8 @@ namespace Microsoft.DotNet.Interactive
 
             invocations.Add(async (command, context, _) =>
             {
-                await _kernel.HandleAsync(command, context);
+                await _kernel.HandleInternalAsync(command, context);
+                context.Result = new KernelCommandResult(context.KernelEvents);
             });
 
             return invocations.Aggregate(

--- a/Microsoft.DotNet.Interactive/KernelExtensions.cs
+++ b/Microsoft.DotNet.Interactive/KernelExtensions.cs
@@ -38,8 +38,9 @@ namespace Microsoft.DotNet.Interactive
                 extensionDllArg
             };
 
-            extend.Handler = CommandHandler.Create<FileInfo, KernelInvocationContext>((dll, pipelineContext) =>
-                                                                                        kernel.SendAsync(new LoadExtension(dll)));
+            extend.Handler = CommandHandler.Create<FileInfo, KernelInvocationContext>(
+                (dll, pipelineContext) =>
+                    kernel.SendAsync(new LoadExtension(dll)));
 
             kernel.AddDirective(extend);
 

--- a/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -27,12 +27,6 @@ namespace Microsoft.DotNet.Interactive
 
         public IKernelCommand Command { get; }
 
-        public void Complete()
-        {
-            IsCompleted = true;
-            _events.OnCompleted();
-        }
-
         public void OnError(Exception exception)
         {
             _events.OnError(exception);
@@ -79,8 +73,6 @@ namespace Microsoft.DotNet.Interactive
         public IKernel HandlingKernel { get; set; }
 
         public IKernel CurrentKernel { get; internal set; }
-
-        public bool IsCompleted { get; private set; }
 
         void IDisposable.Dispose() => _currentStack?.Value?.Pop();
     }

--- a/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -27,9 +27,17 @@ namespace Microsoft.DotNet.Interactive
 
         public IKernelCommand Command { get; }
 
+        public bool IsComplete { get; private set; }
+
         public void OnError(Exception exception)
         {
             _events.OnError(exception);
+        }
+
+        public void Complete()
+        {
+            Publish(new CommandHandled(Command));
+            IsComplete = true;
         }
 
         public void Publish(IKernelEvent @event)

--- a/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
+++ b/Microsoft.DotNet.Interactive/KernelInvocationContext.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Subjects;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 
@@ -16,7 +15,6 @@ namespace Microsoft.DotNet.Interactive
         private readonly KernelInvocationContext _parentContext;
         private static readonly AsyncLocal<Stack<KernelInvocationContext>> _currentStack = new AsyncLocal<Stack<KernelInvocationContext>>();
 
-        private readonly KernelCommandInvocation _invocation;
         private readonly ReplaySubject<IKernelEvent> _events = new ReplaySubject<IKernelEvent>();
 
         private KernelInvocationContext(
@@ -25,7 +23,6 @@ namespace Microsoft.DotNet.Interactive
         {
             _parentContext = parentContext;
             Command = command;
-            _invocation = command.InvokeAsync;
         }
 
         public IKernelCommand Command { get; }
@@ -55,19 +52,7 @@ namespace Microsoft.DotNet.Interactive
 
         public IObservable<IKernelEvent> KernelEvents => _events;
 
-        public async Task<IKernelCommandResult> InvokeAsync()
-        {
-            try
-            {
-                await _invocation(this);
-            }
-            catch (Exception exception)
-            {
-                OnError(exception);
-            }
-
-            return new KernelCommandResult(KernelEvents);
-        }
+        public IKernelCommandResult Result { get; internal set; }
 
         public static KernelInvocationContext Establish(IKernelCommand command)
         {

--- a/Microsoft.DotNet.Interactive/NugetPackageReference.cs
+++ b/Microsoft.DotNet.Interactive/NugetPackageReference.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Interactive
 {
     public class NugetPackageReference
     {
-        private static Regex _regex = new Regex(
+        private static readonly Regex _regex = new Regex(
             @"nuget:\s*(?<packageName>[\w\.]+)(\s*,\s*(?<packageVersion>[\w\.\-]+))?",
             RegexOptions.Compiled |
             RegexOptions.CultureInvariant |

--- a/WorkspaceServer.Tests/Kernel/CSharpKernelTests.cs
+++ b/WorkspaceServer.Tests/Kernel/CSharpKernelTests.cs
@@ -574,8 +574,13 @@ catch (Exception e)
                                                      e.Value.As<ExtensionLoaded>().ExtensionPath.FullName.CompareTo(extensionDll.FullName) ==0);
 
             KernelEvents.Should()
-                        .ContainSingle(e => e.Value is CodeSubmissionEvaluated &&
-                                            e.Value.As<CodeSubmissionEvaluated>().Code.Contains("using System.Reflection;"));
+                        .ContainSingle(e => e.Value is CommandHandled &&
+                                            e.Value
+                                            .As<CommandHandled>()
+                                            .Command
+                                            .As<SubmitCode>()
+                                            .Code
+                                            .Contains("using System.Reflection;"));
         }
     }
 }

--- a/WorkspaceServer.Tests/Kernel/CSharpKernelTests.cs
+++ b/WorkspaceServer.Tests/Kernel/CSharpKernelTests.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Tests;
 using MLS.Agent;
 using MLS.Agent.Tools;
 using MLS.Agent.Tools.Tests;
@@ -408,9 +409,7 @@ json
 
             var result = await kernel.SendAsync(command);
 
-            var events = result.KernelEvents
-                               .ToEnumerable()
-                               .ToArray();
+            using var events = result.KernelEvents.ToSubscribedList();
 
             events
                 .Should()
@@ -506,10 +505,7 @@ catch (Exception e)
 
             var result = await kernel.SendAsync(command);
 
-            var events = result.KernelEvents
-                               .Timeout(30.Seconds())
-                               .ToEnumerable()
-                               .ToArray();
+            using var events = result.KernelEvents.ToSubscribedList();
 
             events
                 .Should()

--- a/WorkspaceServer.Tests/Kernel/KernelClientTests.Kernel_can_be_interacted_using_kernel_client.approved.json
+++ b/WorkspaceServer.Tests/Kernel/KernelClientTests.Kernel_can_be_interacted_using_kernel_client.approved.json
@@ -1,7 +1,7 @@
 ﻿{"id":1,"eventType":"CodeSubmissionReceived","event":{"code":"var x = 123;","value":"var x = 123;","command":{"code":"var x = 123;","targetKernelName":null,"submissionType":0}}}
 {"id":1,"eventType":"CompleteCodeSubmissionReceived","event":{"code":"var x = 123;","command":{"code":"var x = 123;","targetKernelName":null,"submissionType":0}}}
-{"id":1,"eventType":"CodeSubmissionEvaluated","event":{"code":"var x = 123;","command":{"code":"var x = 123;","targetKernelName":null,"submissionType":0}}}
+{"id":1,"eventType":"CommandHandled","event":{"command":{"code":"var x = 123;","targetKernelName":null,"submissionType":0}}}
 {"id":2,"eventType":"CodeSubmissionReceived","event":{"code":"x","value":"x","command":{"code":"x","targetKernelName":null,"submissionType":0}}}
 {"id":2,"eventType":"CompleteCodeSubmissionReceived","event":{"code":"x","command":{"code":"x","targetKernelName":null,"submissionType":0}}}
 {"id":2,"eventType":"ReturnValueProduced","event":{"value":123,"formattedValues":[{"mimeType":"text/plain","value":"123"}],"valueId":null,"command":{"code":"x","targetKernelName":null,"submissionType":0}}}
-{"id":2,"eventType":"CodeSubmissionEvaluated","event":{"code":"x","command":{"code":"x","targetKernelName":null,"submissionType":0}}}
+{"id":2,"eventType":"CommandHandled","event":{"command":{"code":"x","targetKernelName":null,"submissionType":0}}}

--- a/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
+++ b/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
@@ -139,7 +139,7 @@ namespace WorkspaceServer.Tests.Kernel
         {
             var kernel = new CompositeKernel
             {
-                new CSharpKernel().UseNugetDirective(),
+                new CSharpKernel().UseNugetDirective()
             };
 
             var input = new MemoryStream();
@@ -155,8 +155,7 @@ namespace WorkspaceServer.Tests.Kernel
                 new StreamReader(input),
                 new StreamWriter(output));
 
-            var task = streamKernel.Start();
-            await task;
+            await streamKernel.Start();
 
             output.Position = 0;
             var reader = new StreamReader(output, Encoding.UTF8);

--- a/WorkspaceServer.Tests/Kernel/KernelExtensionLoaderTests.cs
+++ b/WorkspaceServer.Tests/Kernel/KernelExtensionLoaderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Interactive;
 using FluentAssertions;
 using Microsoft.DotNet.Interactive.Events;
 using System.Collections.Generic;
+using Microsoft.DotNet.Interactive.Commands;
 
 namespace WorkspaceServer.Tests
 {
@@ -26,8 +27,13 @@ namespace WorkspaceServer.Tests
             await new KernelExtensionLoader().LoadFromAssembly(extensionDll, kernel, (kernelEvent) => extensionLoadEvents.Add(kernelEvent));
 
             KernelEvents.Should()
-                      .ContainSingle(e => e.Value is CodeSubmissionEvaluated &&
-                                          e.Value.As<CodeSubmissionEvaluated>().Code.Contains("using System.Reflection;"));
+                        .ContainSingle(e => e.Value is CommandHandled &&
+                                            e.Value
+                                             .As<CommandHandled>()
+                                             .Command
+                                             .As<SubmitCode>()
+                                             .Code
+                                             .Contains("using System.Reflection;"));
 
         }
 

--- a/WorkspaceServer.Tests/PackageRestoreContextTests.cs
+++ b/WorkspaceServer.Tests/PackageRestoreContextTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using FluentAssertions;
-using System.Linq;
 using System.Threading.Tasks;
 using WorkspaceServer.Packaging;
 using Xunit;

--- a/WorkspaceServer/Kernel/CSharpKernel.cs
+++ b/WorkspaceServer/Kernel/CSharpKernel.cs
@@ -220,7 +220,7 @@ namespace WorkspaceServer.Kernel
                                 formattedValues));
                     }
 
-                    context.Publish(new CommandHandled(submitCode));
+                    context.Complete();
                 }
             }
             else

--- a/WorkspaceServer/Kernel/CSharpKernel.cs
+++ b/WorkspaceServer/Kernel/CSharpKernel.cs
@@ -131,7 +131,6 @@ namespace WorkspaceServer.Kernel
             }
 
             context.Publish(reply);
-            context.Complete();
         }
 
         private async Task HandleSubmitCode(
@@ -236,8 +235,6 @@ namespace WorkspaceServer.Kernel
             {
                 context.Publish(new CommandFailed(null, submitCode, "Command cancelled"));
             }
-
-            context.Complete();
         }
 
         private void PublishOutput(

--- a/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
+++ b/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
@@ -80,7 +80,6 @@ using static {typeof(Microsoft.DotNet.Interactive.Kernel).FullName};
                     }
 
                     context.Publish(new NuGetPackageAdded(addPackage, package));
-                    context.Complete();
                 };
 
                 await pipelineContext.HandlingKernel.SendAsync(addPackage);

--- a/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
+++ b/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
@@ -43,12 +43,6 @@ using static {typeof(Microsoft.DotNet.Interactive.Kernel).FullName};
             return kernel;
         }
 
-        public interface INativeAssemblyLoadHelper
-        {
-            void Handle(string assembly);
-            void Configure(string v);
-        }
-
         public static CSharpKernel UseNugetDirective(this CSharpKernel kernel, INativeAssemblyLoadHelper helper = null)
         {
             var packageRefArg = new Argument<NugetPackageReference>((SymbolResult result, out NugetPackageReference reference) =>

--- a/WorkspaceServer/Kernel/INativeAssemblyLoadHelper.cs
+++ b/WorkspaceServer/Kernel/INativeAssemblyLoadHelper.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace WorkspaceServer.Kernel
+{
+    public interface INativeAssemblyLoadHelper
+    {
+        void Handle(string assembly);
+        void Configure(string v);
+    }
+}

--- a/WorkspaceServer/Packaging/PackageRestoreContext.cs
+++ b/WorkspaceServer/Packaging/PackageRestoreContext.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -27,12 +28,12 @@ namespace WorkspaceServer.Packaging
             packageBuilder.CreateUsingDotnet("console");
             packageBuilder.TrySetLanguageVersion("8.0");
             packageBuilder.AddPackageReference("Newtonsoft.Json");
-            var package = packageBuilder.GetPackage() as Package;
+            var package = (Package) packageBuilder.GetPackage();
             await package.CreateRoslynWorkspaceForRunAsync(new Budget());
             return package;
         }
 
-        public async Task<IEnumerable<MetadataReference>> AddPackage(string packageName, string packageVersion)
+        public async Task<IReadOnlyCollection<MetadataReference>> AddPackage(string packageName, string packageVersion)
         {
             var package = await _lazyPackage.ValueAsync();
             var currentWorkspace = await package.CreateRoslynWorkspaceForRunAsync(new Budget());
@@ -51,15 +52,7 @@ namespace WorkspaceServer.Packaging
             var newWorkspace = await package.CreateRoslynWorkspaceForRunAsync(new Budget());
             var newRefs = new HashSet<MetadataReference>(newWorkspace.CurrentSolution.Projects.First().MetadataReferences);
 
-            var resultRefs = newRefs.Where(n => !currentRefs.Contains(n.Display));
-            return resultRefs;
-        }
-
-        public async Task<IEnumerable<MetadataReference>> GetAllReferences()
-        {
-            var package = await _lazyPackage.ValueAsync();
-            var currentWorkspace = await package.CreateRoslynWorkspaceForRunAsync(new Budget());
-            return currentWorkspace.CurrentSolution.Projects.First().MetadataReferences;
+            return newRefs.Where(n => !currentRefs.Contains(n.Display)).ToArray();
         }
     }
 }

--- a/WorkspaceServer/Packaging/ToolPackageLocator.cs
+++ b/WorkspaceServer/Packaging/ToolPackageLocator.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/WorkspaceServer/Servers/Scripting/WorkspaceFixture.cs
+++ b/WorkspaceServer/Servers/Scripting/WorkspaceFixture.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 
@@ -15,7 +13,6 @@ namespace WorkspaceServer.Servers.Scripting
     {
         private readonly AdhocWorkspace _workspace = new AdhocWorkspace(MefHostServices.DefaultHost);
         private readonly DocumentId _documentId;
-        private Project _project;
 
         public WorkspaceFixture(
             CompilationOptions compilationOptions,
@@ -40,7 +37,7 @@ namespace WorkspaceServer.Servers.Scripting
                 compilationOptions: compilationOptions,
                 metadataReferences: metadataReferences);
 
-            _project =  _workspace.AddProject(projectInfo);
+            _workspace.AddProject(projectInfo);
 
             _documentId = DocumentId.CreateNewId(projectId, "ScriptDocument");
 
@@ -49,16 +46,6 @@ namespace WorkspaceServer.Servers.Scripting
                 sourceCodeKind: SourceCodeKind.Script);
 
             _workspace.AddDocument(documentInfo);
-        }
-
-
-        public WorkspaceFixture(
-            IEnumerable<string> defaultUsings,
-            ImmutableArray<MetadataReference> metadataReferences) : this(new CSharpCompilationOptions(
-            OutputKind.DynamicallyLinkedLibrary,
-            usings: defaultUsings), metadataReferences)
-        {
-            
         }
 
         public Document ForkDocument(string text)

--- a/WorkspaceServer/Servers/Scripting/WorkspaceFixture.cs
+++ b/WorkspaceServer/Servers/Scripting/WorkspaceFixture.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
@@ -16,7 +16,7 @@ namespace WorkspaceServer.Servers.Scripting
 
         public WorkspaceFixture(
             CompilationOptions compilationOptions,
-            ImmutableArray<MetadataReference> metadataReferences)
+            IEnumerable<MetadataReference> metadataReferences)
         {
             if (compilationOptions == null)
             {
@@ -26,6 +26,9 @@ namespace WorkspaceServer.Servers.Scripting
             {
                 throw new ArgumentNullException(nameof(metadataReferences));
             }
+
+            MetadataReferences = metadataReferences;
+
             var projectId = ProjectId.CreateNewId("ScriptProject");
 
             var projectInfo = ProjectInfo.Create(
@@ -47,6 +50,8 @@ namespace WorkspaceServer.Servers.Scripting
 
             _workspace.AddDocument(documentInfo);
         }
+
+        public IEnumerable<MetadataReference> MetadataReferences { get; }
 
         public Document ForkDocument(string text)
         {

--- a/WorkspaceServer/WorkspaceServer.csproj
+++ b/WorkspaceServer/WorkspaceServer.csproj
@@ -9,8 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="PackageRestore\**" />
     <Compile Remove="TestResults\**" />
+    <EmbeddedResource Remove="PackageRestore\**" />
     <EmbeddedResource Remove="TestResults\**" />
+    <None Remove="PackageRestore\**" />
     <None Remove="TestResults\**" />
   </ItemGroup>
 
@@ -97,7 +100,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="PackageRestore\" />
     <Folder Include="Properties\" />
   </ItemGroup>
 

--- a/docs/test_example/test_example.csproj
+++ b/docs/test_example/test_example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
This resolves an issue where the kernel's actual command handling was happening after pipeline execution returns, rather than as the last step in the pipeline.

Fixing this unblocks the ability to see `CSharpKernel.ScriptState` either before or after a submission is applied.