### PR TITLE
auto-reference XPlot from F# kernel

### DIFF
--- a/FSharpWorkspaceShim/FSharpWorkspaceShim.fsproj
+++ b/FSharpWorkspaceShim/FSharpWorkspaceShim.fsproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.3-beta.19425.1" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19460.2" />
     <PackageReference Include="FSharp.Compiler.Service" Version="28.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.1.0-beta3-final" />
   </ItemGroup>

--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -519,6 +519,7 @@ namespace MLS.Agent.CommandLine
                                              .UseXplot(),
                                          new FSharpKernel()
                                              .UseDefaultRendering()
+                                             .UseXplot()
                                      }
                                      .UseDefaultMagicCommands()
                                      .UseExtendDirective();

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -37,7 +37,7 @@ type FSharpKernel() =
 
     let handleCancelCurrentCommand (cancelCurrentCommand: CancelCurrentCommand) (context: KernelInvocationContext) =
         async {
-            let reply = CurrentCommandCancelled(cancelCurrentCommand)           
+            let reply = CurrentCommandCancelled(cancelCurrentCommand)
             context.Publish(reply)
         }
 
@@ -48,4 +48,3 @@ type FSharpKernel() =
             | :? CancelCurrentCommand as cancelCurrentCommand -> cancelCurrentCommand.Handler <- fun invocationContext -> (handleCancelCurrentCommand cancelCurrentCommand invocationContext) |> Async.StartAsTask :> Task
             | _ -> ()
         } |> Async.StartAsTask :> Task
-

--- a/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Private.Scripting" Version="10.5.0-beta.19425.1" />
-    <PackageReference Include="FSharp.Core" Version="4.6.3-beta.19425.1" />
+    <PackageReference Include="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19460.2" />
+    <PackageReference Include="FSharp.Core" Version="5.0.0-beta.19460.2" />
   </ItemGroup>
 
 </Project>

--- a/WorkspaceServer/Kernel/FSharpKernelExtensions.cs
+++ b/WorkspaceServer/Kernel/FSharpKernelExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.FSharp;
+using XPlot.Plotly;
 
 namespace WorkspaceServer.Kernel
 {
@@ -20,7 +21,9 @@ namespace WorkspaceServer.Kernel
                          new SubmitCode($@"
 {ReferenceFromType(typeof(IHtmlContent))}
 {ReferenceFromType(typeof(FSharpPocketViewTags))}
+{ReferenceFromType(typeof(PlotlyChart))}
 open {typeof(FSharpPocketViewTags).FullName}
+open {typeof(PlotlyChart).Namespace}
 "))).Wait();
 
             return kernel;


### PR DESCRIPTION
This required a minor update to F# to allow scripts with multiple code segments to return the last computed value.  See dotnet/fsharp#7524.

With this we can now do this (note, this is the **entire** notebook, no extra setup):
![image](https://user-images.githubusercontent.com/926281/64652769-7c670100-d3d9-11e9-8f54-5195e3429005.png)

(Example borrowed from the [official XPlot docs](https://fslab.org/XPlot/chart/plotly-bar-charts.html).)