### PR TITLE
build pre-release versions of the appropriate packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,8 +20,6 @@
     <PackageReference Update="FSharp.Compiler.Service" Version="28.0.0" />
   </ItemGroup>
 
-  <Target Name="_InitializeAssemblyVersion">
-    <!-- don't let Arcade override assembly versions -->
-  </Target>
+  <Import Project="eng\targets\Versions.targets" Condition="'$(UseStableVersion)' == 'true'" />
 
 </Project>

--- a/MLS.Agent/Directory.Build.Props
+++ b/MLS.Agent/Directory.Build.Props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseStableVersion>true</UseStableVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,0 +1,27 @@
+<Project>
+
+  <!--
+
+  This file is a terrible hack.
+
+
+  The `dotnet-try.*.nupkg` package is never rebuilt to have a stable version because that's handled manually.  The fix
+  is to not allow it to be picked up by the repack targets by temporarily renaming it before the
+  `PackageReleasePackages` target and restoring it's name after.
+  -->
+
+  <ItemGroup>
+    <DotNetTryPackages Include="$(ArtifactsShippingPackagesDir)\dotnet-try.*.nupkg" />
+  </ItemGroup>
+
+  <!-- Appends the extension `.renamed` to the dotnet-try package to force the glob `*.nupkg` to not pick it up. -->
+  <Target Name="RenameDotNetTryOutputPackage" BeforeTargets="PackageReleasePackages">
+    <Move SourceFiles="%(DotNetTryPackages.FullPath)" DestinationFiles="%(DotNetTryPackages.FullPath).renamed" />
+  </Target>
+
+  <!-- Removes the `.renamed` extension from the dotnet-try package. -->
+  <Target Name="RestoreDotNetTryOutputPackage" AfterTargets="PackageReleasePackages">
+    <Move SourceFiles="%(DotNetTryPackages.FullPath).renamed" DestinationFiles="%(DotNetTryPackages.FullPath)" />
+  </Target>
+
+</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,14 +3,16 @@
     <!-- opt-out properties -->
     <UsingToolSourceLink>false</UsingToolSourceLink>
     <!-- opt-in properties -->
+    <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <TestRunnerAdditionalArguments>-parallel none</TestRunnerAdditionalArguments>
   </PropertyGroup>
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion> 
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <PatchVersion>0</PatchVersion>
+    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- package settings -->
@@ -20,7 +22,10 @@
     <PublishRepositoryUrl>false</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/dotnet/try</RepositoryUrl>
   </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(UseStableVersion)' == 'true'">
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
     <!--
     Mimic the build number calculation from here:
     https://github.com/dotnet/arcade/blob/ce8e852e418ca52d28e562f9697fbb926d0b0bb1/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets#L24-L36

--- a/eng/targets/Versions.targets
+++ b/eng/targets/Versions.targets
@@ -1,0 +1,7 @@
+<Project>
+
+  <Target Name="_InitializeAssemblyVersion">
+    <!-- don't let Arcade override assembly versions -->
+  </Target>
+
+</Project>


### PR DESCRIPTION
The `artifacts/packages/$(Configuration)` directory will now look like the following (subset):

- Release
  - Microsoft.DotNet.Try.Markdown.1.0.0.nupkg
- Shipping
  - dotnet-try.1.0.19462.0.nupkg
  - Microsoft.DotNet.Try.Markdown.1.0.0-beta.19462.0.nupkg

With this, the `dotnet-try` package always has a date-stamped version.  This is unchanged from what we had before.

The real change is that other packages (e.g., `Microsoft.DotNet.Try.Markdown`) will produce both a `1.0.0` **and** `1.0.0-beta.<timestamp>` version, which means we can publish the `*-beta.*` packages as appropriate and when we decide we want to promote one of those to release, we simply upload the corresponding `1.0.0` package from the `Release` directory.

The only caveat is that once we've shipped a `Release` version of a package, we'll need to increment the `1.0.0` version to `1.0.1`, `1.0.2`, etc.  When it comes to that, however, the `dotnet-try` package will be insulated and will continue to produce `1.0.<datestamp>.<buildNumber>`.