### PR TITLE
Improve path discovery for Kernel extensions

### DIFF
--- a/WorkspaceServer.Tests/PackageRestoreContextTests.cs
+++ b/WorkspaceServer.Tests/PackageRestoreContextTests.cs
@@ -50,5 +50,15 @@ namespace WorkspaceServer.Tests
             path.FullName.Should().EndWith("htmlagilitypack" + Path.DirectorySeparatorChar + "1.11.12");
             path.Exists.Should().BeTrue();
         }
+
+        [Fact]
+        public async Task Can_get_path_to_nuget_package_which_doesnt_have_lib_folder()
+        {
+            var packageRestoreContext = new PackageRestoreContext();
+            await packageRestoreContext.AddPackage("roslyn.analyzers", "1.0.3.4");
+            var path = await packageRestoreContext.GetDirectoryForPackage("roslyn.analyzers");
+            path.FullName.Should().EndWith("roslyn.analyzers" + Path.DirectorySeparatorChar + "1.0.3.4");
+            path.Exists.Should().BeTrue();
+        }
     }
 }

--- a/WorkspaceServer/Packaging/PackageRestoreContext.cs
+++ b/WorkspaceServer/Packaging/PackageRestoreContext.cs
@@ -102,20 +102,20 @@ namespace WorkspaceServer.Packaging
 @"  <Target Name='ComputePackageRoots' BeforeTargets='CoreCompile;PrintNuGetPackagesPaths' DependsOnTargets='CollectPackageReferences'>
         <ItemGroup>
         <!-- Read the package path from the Pkg{PackageName} properties that are present in the nuget.g.props file -->
-            <AddedNuGetPackage Include='@(ResolvedCompileFileDefinitions)'>
-                <PackageRootProperty>Pkg$([System.String]::Copy('%(ResolvedCompileFileDefinitions.NugetPackageId)').Replace('.','_'))</PackageRootProperty>
+            <AddedNuGetPackage Include='@(PackageReference)'>
+                <PackageRootProperty>Pkg$([System.String]::Copy('%(PackageReference.Identity)').Replace('.','_'))</PackageRootProperty>
                 <PackageRoot>$(%(AddedNuGetPackage.PackageRootProperty))</PackageRoot>
             </AddedNuGetPackage>
         </ItemGroup>
 
-        <Message Text=""Done: Read package root : %(AddedNuGetPackage.PackageRoot) for %(AddedNuGetPackage.NuGetPackageId)"" Condition=""%(AddedNuGetPackage.PackageRoot) != ''"" Importance=""high""/>
+        <Message Text=""Done: Read package root : %(AddedNuGetPackage.PackageRoot) for %(AddedNuGetPackage.Identity)"" Condition=""%(AddedNuGetPackage.PackageRoot) != ''"" Importance=""high""/>
     </Target>";
 
             const string writePackageRootsToDiskTarget =
 @"  <Target Name='PrintNuGetPackagesPaths' DependsOnTargets='ResolvePackageAssets;ComputePackageRoots' AfterTargets='PrepareForBuild'>
         <ItemGroup>
             <ReferenceLines Remove='@(ReferenceLines)' />
-            <ReferenceLines Include='%(AddedNuGetPackage.NuGetPackageId),%(AddedNuGetPackage.PackageRoot)' Condition=""%(AddedNuGetPackage.PackageRoot) != ''""/>
+            <ReferenceLines Include='%(AddedNuGetPackage.Identity),%(AddedNuGetPackage.PackageRoot)' Condition=""%(AddedNuGetPackage.PackageRoot) != ''""/>
         </ItemGroup>
 
         <WriteLinesToFile Lines='@(ReferenceLines)' File='$(MSBuildProjectFullPath).nuget.paths' Overwrite='True' WriteOnlyWhenDifferent='True' />


### PR DESCRIPTION
"ResolvedCompileFileDefinitions" doesn't include the packages that do not have a "lib" folder. However in case of the "KernelExtension" nuget package, we may just have a "interactive-extensions/dotnet/.." folder.

Hence we should use the "PackageReference" property to do the path discovery