### PR TITLE
allow nuget package loading from F# kernel

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,8 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19460.2" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19460.2" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19463.12" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19463.12" />
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
**Note: this has one large caveat, see below.**

Updates the F# packages to one that allows `#r "nuget:*"`.  Also includes code to handle the loading of kernel extensions (untested).

![image](https://user-images.githubusercontent.com/926281/65079950-13d9d000-d955-11e9-9a7f-d91201d3a15a.png)

**Caveat:**
There is currently a bug in how F# resolves NuGet dependencies that requires the environment variable `DOTNET_HOST_PATH` be set to the string `dotnet.exe`.  See dotnet/fsharp#7582.