### PR TITLE
add MyGet package upload to build stage on master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,255 +24,266 @@ variables:
   - name: TryDotNetPackagesPath
     value: $(Build.SourcesDirectory)/artifacts/.trydotnet/packages
 
-jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableMicrobuild: true
-    enablePublishBuildArtifacts: true
-    enablePublishTestResults: true
-    enablePublishBuildAssets: false
-    enablePublishUsingPipelines: $(_PublishUsingPipelines)
-    enableTelemetry: true
-    helixRepo: dotnet/try
-    jobs:
-    - job: Windows_NT
-      pool:
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+stages:
+- stage: build
+  displayName: Build and Test
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: false
+      enablePublishUsingPipelines: $(_PublishUsingPipelines)
+      enableTelemetry: true
+      helixRepo: dotnet/try
+      jobs:
+      - job: Windows_NT
+        pool:
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            vmImage: windows-2019
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCoreInternal-Pool
+            queue: buildpool.windows.10.amd64.vs2019
+        variables:
+        # Enable signing for internal, non-PR builds
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - name: _SignType
+            value: Real
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
+              /p:DotNetSignType=$(_SignType)
+              /p:MicroBuild_SigningEnabled=true
+              /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:TeamName=$(_TeamName)
+              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        # else
+        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          - name: _SignType
+            value: Test
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
+        steps:
+        - script: git config --global core.longpaths true
+          displayName: Enable `git clean` to handle long paths
+
+        - checkout: self
+          clean: true
+
+        - task: NodeTool@0
+          displayName: Add NodeJS/npm
+          inputs:
+            versionSpec: $(NodeJSVersion)
+
+        - task: UseDotNet@2
+          displayName: Add dotnet
+          inputs:
+            packageType: sdk
+            version: $(DotNetSdkVersion)
+            installationPath: $(Agent.ToolsDirectory)\dotnet
+
+        - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
+          displayName: Install Blazor templates
+
+        - script: |
+            robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"
+            :: robocopy return codes are terrible; 1 means files were copied
+            if "%errorlevel%" == "1" exit /b 0
+            exit /b 1
+          displayName: Prevent test directory crawling
+
+        - script: eng\CIBuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            -sign
+            -test
+            $(_BuildArgs)
+          displayName: Build / Test
+          env:
+            TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+
+        - task: PublishTestResults@2
+          displayName: Publish NPM Test Results
+          inputs:
+            testResultsFormat: 'VSTest'
+            testResultsFiles: '*.trx'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          continueOnError: true
+          condition: always()
+
+        - task: PublishBuildArtifacts@1
+          displayName: Publish packages to artifacts container
+          inputs:
+            pathToPublish: $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)
+            artifactName: packages
+            artifactType: container
+
+        - task: PublishBuildArtifacts@1
+          displayName: Publish integration tests dll
+          inputs:
+            pathToPublish: $(Build.SourcesDirectory)\artifacts\bin\NotIntegration.Tests\$(_BuildConfig)
+            artifactName: integrationTests
+            artifactType: container
+
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: false
+      enablePublishUsingPipelines: $(_PublishUsingPipelines)
+      enableTelemetry: true
+      helixRepo: dotnet/try
+      jobs:
+      - job: Linux
+        pool:
+          vmImage: ubuntu-16.04
+        variables:
+        # Enable signing for internal, non-PR builds
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - name: _SignType
+            value: Test
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
+              /p:DotNetSignType=$(_SignType)
+              /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:TeamName=$(_TeamName)
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        # else
+        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          - name: _SignType
+            value: Test
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
+        steps:
+        - script: git config --global core.longpaths true
+          displayName: Enable `git clean` to handle long paths
+
+        - checkout: self
+          clean: true
+
+        - task: NodeTool@0
+          displayName: Add NodeJS/npm
+          inputs:
+            versionSpec: $(NodeJSVersion)
+
+        - task: UseDotNet@2
+          displayName: Add dotnet
+          inputs:
+            packageType: sdk
+            version: $(DotNetSdkVersion)
+            installationPath: $(Agent.ToolsDirectory)/dotnet
+
+        - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
+          displayName: Install Blazor templates
+
+        - script: |
+            mkdir -p "$(Build.SourcesDirectory)/artifacts"
+            cp eng/resources/* "$(Build.SourcesDirectory)/artifacts"
+          displayName: Prevent test directory crawling
+
+        - script: ./eng/cibuild.sh
+            --configuration $(_BuildConfig)
+            --prepareMachine
+            --test
+          displayName: Build / Test
+          env:
+            TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+
+        - task: PublishTestResults@2
+          displayName: Publish NPM Test Results
+          inputs:
+            testResultsFormat: 'VSTest'
+            testResultsFiles: '*.trx'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          continueOnError: true
+          condition: always()
+
+      # Up-to-date
+      - job: UpToDate_Windows
+        pool:
           vmImage: windows-2019
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2019
-      variables:
-      # Enable signing for internal, non-PR builds
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _SignType
-          value: Real
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-            /p:DotNetSignType=$(_SignType)
-            /p:MicroBuild_SigningEnabled=true
-            /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            /p:TeamName=$(_TeamName)
-            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-      # else
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _SignType
-          value: Test
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-      steps:
-      - script: git config --global core.longpaths true
-        displayName: Enable `git clean` to handle long paths
+        steps:
+        - checkout: self
+          clean: true
+        - task: NodeTool@0
+          displayName: Add NodeJS/npm
+          inputs:
+            versionSpec: $(NodeJSVersion)
+        - task: UseDotNet@2
+          displayName: Add dotnet
+          inputs:
+            packageType: sdk
+            version: $(DotNetSdkVersion)
+            installationPath: $(Agent.ToolsDirectory)/dotnet
+        - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
+          displayName: Install Blazor templates
+        - task: PowerShell@2
+          displayName: Run up-to-date build check
+          inputs:
+            filePath: eng\tests\UpToDate.ps1
+            arguments: -configuration $(_BuildConfig) -restore -ci
 
-      - checkout: self
-        clean: true
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enableTelemetry: true
+      helixRepo: dotnet/try
+      jobs:
+      - job: IntegrationTest
+        dependsOn: Windows_NT
+        condition: succeeded()
+        pool:
+          vmImage: ubuntu-16.04
+        variables:
+          - name: PACKAGESOURCE
+            value: $(System.DefaultWorkingDirectory)/packages/Shipping
+          - name: RUN_DOTNET_TRY_INTEGRATION_TESTS
+            value: true
+          - name: TryDotNetPackagesPath
+            value: $(Build.SourcesDirectory)/.trydotnet/packages
+        steps:
+        - checkout: none #skip checking out the default repository resource
+        - task: UseDotNet@2
+          displayName: Add dotnet
+          inputs:
+            packageType: sdk
+            version: $(DotNetSdkVersion)
+            installationPath: $(Agent.ToolsDirectory)/dotnet
 
-      - task: NodeTool@0
-        displayName: Add NodeJS/npm
-        inputs:
-          versionSpec: $(NodeJSVersion)
+        - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
+          displayName: Install Blazor templates
 
-      - task: UseDotNet@2
-        displayName: Add dotnet
-        inputs:
-          packageType: sdk
-          version: $(DotNetSdkVersion)
-          installationPath: $(Agent.ToolsDirectory)\dotnet
+        - task: DownloadBuildArtifacts@0
+          displayName: 'Download built packages'
+          inputs:
+            artifactName: packages
+            downloadPath: $(System.DefaultWorkingDirectory)
 
-      - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
-        displayName: Install Blazor templates
+        - task: DownloadBuildArtifacts@0
+          displayName: 'Download built integrationtests'
+          inputs:
+            artifactName: integrationTests
+            downloadPath: $(System.DefaultWorkingDirectory)
 
-      - script: |
-          robocopy "eng\resources" "$(Build.SourcesDirectory)\artifacts"
-          :: robocopy return codes are terrible; 1 means files were copied
-          if "%errorlevel%" == "1" exit /b 0
-          exit /b 1
-        displayName: Prevent test directory crawling
+        - script: dotnet vstest $(System.DefaultWorkingDirectory)/integrationTests/netcoreapp3.0/NotIntegration.Tests.dll --ResultsDirectory:$(System.DefaultWorkingDirectory)/testResults | tee $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\log.txt
+          displayName: Run integration tests
 
-      - script: eng\CIBuild.cmd
-          -configuration $(_BuildConfig)
-          -prepareMachine
-          -sign
-          -test
-          $(_BuildArgs)
-        displayName: Build / Test
-        env:
-          TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
+        - task: PublishTestResults@2
+          displayName: Publish NPM Test Results
+          inputs:
+            testResultsFormat: 'VSTest'
+            testResultsFiles: '*.trx'
+            searchFolder: '$(SystemWorkingDirectory)/testResults'
+          continueOnError: true
+          condition: always()
 
-      - task: PublishTestResults@2
-        displayName: Publish NPM Test Results
-        inputs:
-          testResultsFormat: 'VSTest'
-          testResultsFiles: '*.trx'
-          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        continueOnError: true
-        condition: always()
-
-      - task: PublishBuildArtifacts@1
-        displayName: Publish packages to artifacts container
-        inputs:
-          pathToPublish: $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)
-          artifactName: packages
-          artifactType: container
-
-      - task: PublishBuildArtifacts@1
-        displayName: Publish integration tests dll
-        inputs:
-          pathToPublish: $(Build.SourcesDirectory)\artifacts\bin\NotIntegration.Tests\$(_BuildConfig)
-          artifactName: integrationTests
-          artifactType: container
-
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableMicrobuild: true
-    enablePublishBuildArtifacts: true
-    enablePublishTestResults: true
-    enablePublishBuildAssets: false
-    enablePublishUsingPipelines: $(_PublishUsingPipelines)
-    enableTelemetry: true
-    helixRepo: dotnet/try
-    jobs:
-    - job: Linux
-      pool:
-        vmImage: ubuntu-16.04
-      variables:
-      # Enable signing for internal, non-PR builds
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _SignType
-          value: Test
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-            /p:DotNetSignType=$(_SignType)
-            /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            /p:TeamName=$(_TeamName)
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-      # else
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _SignType
-          value: Test
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-      steps:
-      - script: git config --global core.longpaths true
-        displayName: Enable `git clean` to handle long paths
-
-      - checkout: self
-        clean: true
-
-      - task: NodeTool@0
-        displayName: Add NodeJS/npm
-        inputs:
-          versionSpec: $(NodeJSVersion)
-
-      - task: UseDotNet@2
-        displayName: Add dotnet
-        inputs:
-          packageType: sdk
-          version: $(DotNetSdkVersion)
-          installationPath: $(Agent.ToolsDirectory)/dotnet
-
-      - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
-        displayName: Install Blazor templates
-
-      - script: |
-          mkdir -p "$(Build.SourcesDirectory)/artifacts"
-          cp eng/resources/* "$(Build.SourcesDirectory)/artifacts"
-        displayName: Prevent test directory crawling
-
-      - script: ./eng/cibuild.sh
-          --configuration $(_BuildConfig)
-          --prepareMachine
-          --test
-        displayName: Build / Test
-        env:
-          TRYDOTNET_PACKAGES_PATH: $(TryDotNetPackagesPath)
-
-      - task: PublishTestResults@2
-        displayName: Publish NPM Test Results
-        inputs:
-          testResultsFormat: 'VSTest'
-          testResultsFiles: '*.trx'
-          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        continueOnError: true
-        condition: always()
-
-    # Up-to-date
-    - job: UpToDate_Windows
-      pool:
-        vmImage: windows-2019
-      steps:
-      - checkout: self
-        clean: true
-      - task: NodeTool@0
-        displayName: Add NodeJS/npm
-        inputs:
-          versionSpec: $(NodeJSVersion)
-      - task: UseDotNet@2
-        displayName: Add dotnet
-        inputs:
-          packageType: sdk
-          version: $(DotNetSdkVersion)
-          installationPath: $(Agent.ToolsDirectory)/dotnet
-      - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
-        displayName: Install Blazor templates
-      - task: PowerShell@2
-        displayName: Run up-to-date build check
-        inputs:
-          filePath: eng\tests\UpToDate.ps1
-          arguments: -configuration $(_BuildConfig) -restore -ci
-
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableMicrobuild: true
-    enableTelemetry: true
-    helixRepo: dotnet/try
-    jobs:
-    - job: IntegrationTest
-      dependsOn: Windows_NT
-      condition: succeeded()
-      pool:
-        vmImage: ubuntu-16.04
-      variables:
-        - name: PACKAGESOURCE
-          value: $(System.DefaultWorkingDirectory)/packages/Shipping
-        - name: RUN_DOTNET_TRY_INTEGRATION_TESTS
-          value: true
-        - name: TryDotNetPackagesPath
-          value: $(Build.SourcesDirectory)/.trydotnet/packages
-      steps:
-      - checkout: none #skip checking out the default repository resource
-      - task: UseDotNet@2
-        displayName: Add dotnet
-        inputs:
-          packageType: sdk
-          version: $(DotNetSdkVersion)
-          installationPath: $(Agent.ToolsDirectory)/dotnet
-
-      - script: dotnet new -i Microsoft.AspNetCore.Blazor.Templates::$(BlazorTemplateVersion)
-        displayName: Install Blazor templates
-
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download built packages'
-        inputs:
-          artifactName: packages
-          downloadPath: $(System.DefaultWorkingDirectory)
-
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download built integrationtests'
-        inputs:
-          artifactName: integrationTests
-          downloadPath: $(System.DefaultWorkingDirectory)
-
-      - script: dotnet vstest $(System.DefaultWorkingDirectory)/integrationTests/netcoreapp3.0/NotIntegration.Tests.dll --ResultsDirectory:$(System.DefaultWorkingDirectory)/testResults | tee $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\log.txt
-        displayName: Run integration tests
-
-      - task: PublishTestResults@2
-        displayName: Publish NPM Test Results
-        inputs:
-          testResultsFormat: 'VSTest'
-          testResultsFiles: '*.trx'
-          searchFolder: '$(SystemWorkingDirectory)/testResults'
-        continueOnError: true
-        condition: always()
+#---------------------------------------------------------------------------------------------------------------------#
+#                                                  Package upload                                                     #
+#---------------------------------------------------------------------------------------------------------------------#
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng/upload/upload-packages.yml
+    parameters:
+      branchToUpload: refs/heads/master

--- a/eng/upload/scripts/UploadPackages.ps1
+++ b/eng/upload/scripts/UploadPackages.ps1
@@ -1,0 +1,44 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [string]$apiKey,
+    [string]$feedUrl,
+    [string]$packagesDir
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $packagePatterns = @(
+        "dotnet-try.*.nupkg",
+        "Microsoft.DotNet.Interactive.*.nupkg", # note that this also matches Microsoft.DotNet.Interactive.Rendering
+        "Microsoft.DotNet.Try.ProjectTemplate.Tutorial.*.nupkg",
+        "MLS.Blazor.*.nupkg",
+        "MLS.WasmCodeRunner.*.nupkg"
+    )
+
+    $errors = 0
+    foreach ($pattern in $packagePatterns) {
+        foreach ($packageName in (Get-Item "$packagesDir\$pattern")) {
+            $fullPath = $packageName.ToString()
+            Write-Host "Uploading package $fullPath."
+            $response = Invoke-WebRequest -Uri $feedUrl -Headers @{"X-NuGet-ApiKey"=$apiKey} -ContentType "multipart/form-data" -InFile "$fullPath" -Method Post -UseBasicParsing
+            if ($response.StatusCode -ne 201) {
+                Write-Host "Failed to upload package.  Status code: $response.StatusCode."
+                $errors++
+            }
+            else {
+                Write-Host "Done."
+            }
+        }
+    }
+
+    exit $errors
+
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/eng/upload/upload-packages.yml
+++ b/eng/upload/upload-packages.yml
@@ -1,0 +1,27 @@
+parameters:
+  branchToUpload: ''
+
+stages:
+- stage: upload
+  dependsOn: build
+  displayName: Upload packages to MyGet
+  jobs:
+  - job: Upload_Packages
+    pool:
+      vmImage: windows-2019
+    variables:
+    - group: dotnet-try-myget-api-keys
+    - name: FeedUrl
+      value: 'https://dotnet.myget.org/F/dotnet-try/api/v2/package'
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download package artifacts
+      inputs:
+        buildType: current
+        artifactName: packages
+    - task: PowerShell@2
+      displayName: Upload packages to MyGet
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/upload/scripts/UploadPackages.ps1
+        arguments: -apiKey $(MyGetAPIKey) -feedUrl $(FeedUrl) -packagesDir $(Build.ArtifactStagingDirectory)\packages\Shipping
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], '${{ parameters.branchToUpload }}'))


### PR DESCRIPTION
This replaces the internal release definition that nobody knows about but me.  I recommend you switch the GH diff to hide white space since the only change to `azure-pipelines.yml` is to indent a bunch of stuff and add a small stub at the very end of the file.

Slightly hacked internal test build [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=359783).