### PR TITLE
fix error with #r "nuget:NewtonSoft.Json"

### DIFF
--- a/WorkspaceServer.Tests/PackageRestoreContextTests.cs
+++ b/WorkspaceServer.Tests/PackageRestoreContextTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using FluentAssertions;
 using System.IO;
 using System.Threading.Tasks;
@@ -20,6 +21,16 @@ namespace WorkspaceServer.Tests
             refs.Should().Contain(r => r.Display.Contains("FluentAssertions.dll"));
             refs.Should().Contain(r => r.Display.Contains("System.Configuration.ConfigurationManager"));
             result.InstalledVersion.Should().Be("5.7.0");
+        }
+
+        [Fact]
+        public async Task Returns_references_when_package_version_is_not_specified()
+        {
+            var result = await new PackageRestoreContext().AddPackage("NewtonSoft.Json");
+            result.Succeeded.Should().BeTrue();
+            var refs = result.References;
+            refs.Should().Contain(r => r.Display.Contains("NewtonSoft.Json.dll", StringComparison.InvariantCultureIgnoreCase));
+            result.InstalledVersion.Should().NotBeNullOrWhiteSpace();
         }
 
         [Fact]

--- a/WorkspaceServer/Packaging/PackageRestoreContext.cs
+++ b/WorkspaceServer/Packaging/PackageRestoreContext.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Clockwise;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using MLS.Agent.Tools;
 
 namespace WorkspaceServer.Packaging
@@ -29,14 +30,13 @@ namespace WorkspaceServer.Packaging
             packageBuilder.CreateRebuildablePackage = true;
             packageBuilder.CreateUsingDotnet("console");
             packageBuilder.TrySetLanguageVersion("8.0");
-            packageBuilder.AddPackageReference("Newtonsoft.Json");
             var package = (Package)packageBuilder.GetPackage();
             await package.CreateRoslynWorkspaceForRunAsync(new Budget());
             AddDirectoryProps(package);
             return package;
         }
 
-        public async Task<AddReferenceResult> AddPackage(string packageName, string packageVersion)
+        public async Task<AddReferenceResult> AddPackage(string packageName, string packageVersion = null)
         {
             var package = await _lazyPackage.ValueAsync();
             var currentWorkspace = await package.CreateRoslynWorkspaceForRunAsync(new Budget());
@@ -72,7 +72,9 @@ namespace WorkspaceServer.Packaging
         {
             var package = await _lazyPackage.ValueAsync();
             var nugetPathsFile = package.Directory.GetFiles("*.nuget.paths").Single();
-            var nugetPackagePaths = File.ReadAllText(Path.Combine(package.Directory.FullName, nugetPathsFile.FullName)).Split(',','\r', '\n').Where(t => !string.IsNullOrWhiteSpace(t)).ToArray();
+            var nugetPackagePaths = File.ReadAllText(Path.Combine(package.Directory.FullName, nugetPathsFile.FullName)).Split(',','\r', '\n')
+                                        .Where(t => !string.IsNullOrWhiteSpace(t))
+                                        .ToArray();
             var pathsDictionary = nugetPackagePaths
                                     .Select((v, i) => new { Index = i, Value = v })
                                     .GroupBy(p => p.Index / 2)

--- a/WorkspaceServer/WorkspaceServer.csproj
+++ b/WorkspaceServer/WorkspaceServer.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="3.4.0-beta2-19467-02" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.4.0-beta2-19467-02" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="NewtonSoft.Json" Version="12.0.02" />
+    <PackageReference Include="NewtonSoft.Json" Version="12.0.2" />
     <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19420.2" />
     <PackageReference Include="System.Reactive" Version="4.1.6" />
     <PackageReference Include="Pocket.Disposable" Version="1.0.5">


### PR DESCRIPTION
This fixes an exception when `#r "nuget:NewtonSoft.Json"` is invoked without specifying a version.