### PR TITLE
capture console output from F# kernel

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,9 +23,10 @@
     <NewtonsoftJsonVersion>12.0.02</NewtonsoftJsonVersion>
     <PocketLoggerVersion>0.3.0</PocketLoggerVersion>
     <SystemDiagnosticsProcessVersion>4.3.0</SystemDiagnosticsProcessVersion>
+    <SystemReactiveVersion>4.1.6</SystemReactiveVersion>
     <SystemRuntimeExtensionsVersion>4.3.0</SystemRuntimeExtensionsVersion>
     <MicrosoftCodeAnalysisCommonVersion>3.4.0-beta2-19467-02</MicrosoftCodeAnalysisCommonVersion>
-     <MicrosoftCodeAnalysisWorkspacesCommonVersion>3.4.0-beta2-19467-02</MicrosoftCodeAnalysisWorkspacesCommonVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonVersion>3.4.0-beta2-19467-02</MicrosoftCodeAnalysisWorkspacesCommonVersion>
     <TaskExtensionsVersion>0.1.8580001</TaskExtensionsVersion>
   </PropertyGroup>
 </Project>

--- a/MLS.Agent.Tools/ConsoleOutput.cs
+++ b/MLS.Agent.Tools/ConsoleOutput.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace WorkspaceServer.Servers.Roslyn
+namespace MLS.Agent.Tools
 {
     public class ConsoleOutput : IDisposable
     {

--- a/MLS.Agent.Tools/MLS.Agent.Tools.csproj
+++ b/MLS.Agent.Tools/MLS.Agent.Tools.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
+    <PackageReference Include="System.Reactive" Version="$(SystemReactiveVersion)" />
     <PackageReference Include="System.Runtime.Extensions" Version="$(SystemRuntimeExtensionsVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisCommonVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonVersion)" />

--- a/MLS.Agent.Tools/TrackingStringWriter.cs
+++ b/MLS.Agent.Tools/TrackingStringWriter.cs
@@ -10,7 +10,7 @@ using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace WorkspaceServer.Servers.Roslyn
+namespace MLS.Agent.Tools
 {
     internal class TrackingStringWriter : StringWriter, IObservable<string>
     {

--- a/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
+++ b/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.csproj
@@ -29,6 +29,7 @@
     <NuspecProperty Include="MicrosoftAspNetCoreHtmlAbstractionsVersion=$(MicrosoftAspNetCoreHtmlAbstractionsVersion)" />
     <NuspecProperty Include="MarkdigVersion=$(MarkdigVersion)" />
     <NuspecProperty Include="SystemCommandLineExperimentalVersion=$(SystemCommandLineExperimentalVersion)" />
+    <NuspecProperty Include="SystemReactiveVersion=$(SystemReactiveVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.nuspec
+++ b/Microsoft.DotNet.Try.Markdown/Microsoft.DotNet.Try.Markdown.nuspec
@@ -14,6 +14,7 @@
                 <dependency id="Newtonsoft.Json" version="$NewtonsoftJsonVersion$" />
                 <dependency id="PocketLogger" version="$PocketLoggerVersion$" />
                 <dependency id="System.Diagnostics.Process" version="$SystemDiagnosticsProcessVersion$" />
+                <dependency id="System.Reactive" version="$SystemReactiveVersion$" />
                 <dependency id="System.Runtime.Extensions" version="$SystemRuntimeExtensionsVersion$" />
                 <dependency id="Microsoft.CodeAnalysis.Common" version="$MicrosoftCodeAnalysisCommonVersion$" />
                 <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$MicrosoftCodeAnalysisWorkspacesCommonVersion$" />

--- a/WorkspaceServer.Tests/ConsoleRedirectionTests.cs
+++ b/WorkspaceServer.Tests/ConsoleRedirectionTests.cs
@@ -6,10 +6,8 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Clockwise;
 using FluentAssertions;
-using FluentAssertions.Extensions;
-using WorkspaceServer.Servers.Roslyn;
+using MLS.Agent.Tools;
 using Xunit;
 
 namespace WorkspaceServer.Tests

--- a/WorkspaceServer.Tests/Instrumentation/InstrumentationEmitterTests.cs
+++ b/WorkspaceServer.Tests/Instrumentation/InstrumentationEmitterTests.cs
@@ -1,14 +1,13 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using MLS.Agent.Tools;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Recipes;
-using WorkspaceServer.Servers.Roslyn;
 using WorkspaceServer.Servers.Roslyn.Instrumentation;
 using Xunit;
 

--- a/WorkspaceServer.Tests/Kernel/FSharpKernelTests.cs
+++ b/WorkspaceServer.Tests/Kernel/FSharpKernelTests.cs
@@ -54,6 +54,32 @@ namespace WorkspaceServer.Tests.Kernel
             AssertLastValue(10);
         }
 
+        [Fact]
+        public async Task kernel_captures_stdout()
+        {
+            var kernel = CreateKernel();
+            await kernel.SendAsync(new SubmitCode("printf \"hello from F#\""));
+            KernelEvents.ValuesOnly()
+                .OfType<StandardOutputValueProduced>()
+                .Last()
+                .Value
+                .Should()
+                .Be("hello from F#");
+        }
+
+        [Fact]
+        public async Task kernel_captures_stderr()
+        {
+            var kernel = CreateKernel();
+            await kernel.SendAsync(new SubmitCode("eprintf \"hello from F#\""));
+            KernelEvents.ValuesOnly()
+                .OfType<StandardErrorValueProduced>()
+                .Last()
+                .Value
+                .Should()
+                .Be("hello from F#");
+        }
+
         private void AssertLastValue(object value)
         {
             KernelEvents.ValuesOnly()

--- a/WorkspaceServer/Servers/Scripting/ScriptingWorkspaceServer.cs
+++ b/WorkspaceServer/Servers/Scripting/ScriptingWorkspaceServer.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.DotNet.Try.Project;
 using Microsoft.DotNet.Try.Protocol;
+using MLS.Agent.Tools;
 using Pocket;
 using WorkspaceServer.Transformations;
 using static Pocket.Logger<WorkspaceServer.Servers.Scripting.ScriptingWorkspaceServer>;

--- a/WorkspaceServer/WorkspaceServer.csproj
+++ b/WorkspaceServer/WorkspaceServer.csproj
@@ -62,7 +62,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="NewtonSoft.Json" Version="12.0.2" />
     <PackageReference Include="system.commandline.experimental" Version="0.3.0-alpha.19420.2" />
-    <PackageReference Include="System.Reactive" Version="4.1.6" />
     <PackageReference Include="Pocket.Disposable" Version="1.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This was mostly just moving the `ConsoleOutput` class to a location accessible by the F# kernel.  ~~Note that this PR has direct conflicts with #494, but I can rebase once that goes in.~~  The testcase added will be a great candidate for the combined unit tests in #482 once that's in.