### PR TITLE
return the proper error type from the F# kernel

### DIFF
--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -41,9 +41,6 @@ type FSharpKernel() as this =
                     script.Eval(codeSubmission.Code)
                 with
                 | ex -> Error(ex), [||]
-            if errors.Length > 0 then
-                let aggregateErrorMessage = System.String.Join("\n", errors)
-                context.Publish(CommandFailed(aggregateErrorMessage, codeSubmission))
             for asm in resolvedAssemblies do
                 let! _success = handleAssemblyReferenceAdded asm context
                 () // don't care
@@ -53,8 +50,10 @@ type FSharpKernel() as this =
                 let formattedValues = FormattedValue.FromObject(value)
                 context.Publish(ReturnValueProduced(value, codeSubmission, formattedValues))
             | Ok(None) -> ()
-            | Error(ex) -> context.OnError(ex)
-            context.Publish(CommandHandled(codeSubmission))
+            | Error(ex) ->
+                let aggregateError = System.String.Join("\n", errors)
+                context.Publish(CommandFailed(ex, codeSubmission, aggregateError))
+            context.Complete()
         }
 
     let handleCancelCurrentCommand (cancelCurrentCommand: CancelCurrentCommand) (context: KernelInvocationContext) =

--- a/WorkspaceServer.Tests/Kernel/LanguageKernelTests.cs
+++ b/WorkspaceServer.Tests/Kernel/LanguageKernelTests.cs
@@ -552,6 +552,30 @@ Console.Write(""value three"");",
         [Theory]
         [InlineData(Language.CSharp)]
         [InlineData(Language.FSharp)]
+        public async Task it_returns_a_similarly_shaped_error(Language language)
+        {
+            var kernel = CreateKernel(language);
+
+            var (source, error) = language switch
+            {
+                Language.CSharp => ("using Not.A.Namespace;", "(1,7): error CS0246: The type or namespace name 'Not' could not be found (are you missing a using directive or an assembly reference?)"),
+                Language.FSharp => ("open Not.A.Namespace", "input.fsx (1,6)-(1,9) typecheck error The namespace or module 'Not' is not defined.")
+            };
+
+            await SubmitCode(kernel, source);
+
+            KernelEvents
+                .ValuesOnly()
+                .OfType<CommandFailed>()
+                .Last()
+                .Message
+                .Should()
+                .Be(error);
+        }
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
         public async Task it_produces_a_final_value_if_the_code_expression_evaluates(Language language)
         {
             var kernel = CreateKernel(language);


### PR DESCRIPTION
The F# kernel was doing the wrong thing to indicate an error; this fixes the issue and ensures the shape of the returned error is similar to C#.

This fits nicely with #502.