### PR TITLE
Fix output

### DIFF
--- a/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -134,9 +134,6 @@ namespace Microsoft.DotNet.Interactive.Jupyter
                         data: formattedValues));
                     break;
                 case StandardOutputValueProduced _:
-                    dataMessage.Enqueue(new DisplayData(
-                        transient: transient,
-                        data: formattedValues));
                     dataMessage.Enqueue(Stream.StdOut(
                         GetPlainTextValueOrDefault(formattedValues, value?.ToString() ?? string.Empty))
                     );

--- a/Microsoft.DotNet.Interactive.Jupyter/Protocol/Stream.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/Protocol/Stream.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Protocol
 
         [JsonProperty("name")]
         public string Name { get; }
+
         [JsonProperty("text")]
         public string Text { get; }
 

--- a/Microsoft.DotNet.Interactive.Jupyter/ZMQ/Message.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/ZMQ/Message.cs
@@ -144,12 +144,17 @@ namespace Microsoft.DotNet.Interactive.Jupyter.ZMQ
                     break;
 
                 case nameof(DisplayData):
+
                 case nameof(UpdateDisplayData):
                     encodedTopic = Encoding.Unicode.GetBytes("display_data");
                     break;
 
                 case nameof(ExecuteResult):
                     encodedTopic = Encoding.Unicode.GetBytes("execute_result");
+                    break;
+
+                case nameof(Stream):
+                    encodedTopic = Encoding.Unicode.GetBytes("stream");
                     break;
 
                 case nameof(Error):


### PR DESCRIPTION
Console and output from interactive to Jupyter, had a couple of issues.

1.  It enqueued StandardOutputValueProduced  twice, doubling up the output.

2. It didn't handle protocol stream correctly.  So it only actually produced the first line.

Repro:
Console.WriteLine a couple of lines, and see only one produced.  Either C# or F#.

![image](https://user-images.githubusercontent.com/5175830/66464165-4dbd6400-ea33-11e9-9768-9656a8d40476.png)


With Fix:
![image](https://user-images.githubusercontent.com/5175830/66464348-a8ef5680-ea33-11e9-8fb7-61f83a0a7721.png)



