### PR TITLE
parameterize kernel rendering tests based on language

### DIFF
--- a/MLS.Agent/CommandLine/CommandLineParser.cs
+++ b/MLS.Agent/CommandLine/CommandLineParser.cs
@@ -545,6 +545,7 @@ namespace MLS.Agent.CommandLine
                                              .UseXplot(),
                                          new FSharpKernel()
                                              .UseDefaultRendering()
+                                             .UseKernelHelpers()
                                              .UseXplot()
                                      }
                                      .UseDefaultMagicCommands()

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernelHelpers.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernelHelpers.fs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Interactive.FSharp
+
+open Microsoft.DotNet.Interactive
+
+module FSharpKernelHelpers =
+    let display (value: obj) =
+        Kernel.display value
+    let Javascript (content: string) =
+        Kernel.Javascript content

--- a/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Compile Include="FSharpKernel.fs" />
+    <Compile Include="FSharpKernelHelpers.fs" />
     <Compile Include="FSharpPocketViewTags.fs" />
   </ItemGroup>
 

--- a/WorkspaceServer.Tests/Kernel/LanguageKernelRenderingTests.cs
+++ b/WorkspaceServer.Tests/Kernel/LanguageKernelRenderingTests.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using System.Linq;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Extensions;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
@@ -16,23 +15,31 @@ using Xunit;
 using Xunit.Abstractions;
 using static Pocket.Logger;
 
+#pragma warning disable 8509
 namespace WorkspaceServer.Tests.Kernel
 {
-    public class CSharpKernelRenderingTests : LanguageKernelTestBase
+    public class LanguageKernelRenderingTests : LanguageKernelTestBase
     {
-        public CSharpKernelRenderingTests(ITestOutputHelper output) : base(output)
+        public LanguageKernelRenderingTests(ITestOutputHelper output) : base(output)
         {
         }
 
         [Theory]
-        [InlineData("b(123) // PocketView", "<b>123</b>")]
-        [InlineData("new[] { 1, 2, 3, 4 } // sequence", "<table>")]
-        [InlineData("new[] { new { a = 123 }, new { a = 456 } } // sequence of anonymous objects", "<table>")]
+        // PocketView
+        [InlineData(Language.CSharp, "b(123)", "<b>123</b>")]
+        [InlineData(Language.FSharp, "b.innerHTML(123)", "<b>123</b>")]
+        // sequence
+        [InlineData(Language.CSharp, "new[] { 1, 2, 3, 4 }", "<table>")]
+        [InlineData(Language.FSharp, "[1; 2; 3; 4]", "<table>")]
+        // sequence of anonymous objects
+        [InlineData(Language.CSharp, "new[] { new { a = 123 }, new { a = 456 } }", "<table>")]
+        [InlineData(Language.FSharp, "[{| a = 123 |}; {| a = 456 |}]", "<table>")]
         public async Task Default_rendering_is_HTML(
+            Language language,
             string submission,
             string expectedContent)
         {
-            var kernel = CreateKernel();
+            var kernel = CreateKernel(language);
 
             var result = await kernel.SendAsync(new SubmitCode(submission));
 
@@ -53,14 +60,18 @@ namespace WorkspaceServer.Tests.Kernel
         }
 
         [Theory]
-        [InlineData("div(123).ToString()", "<div>123</div>")]
-        [InlineData("display(div(123).ToString());", "<div>123</div>")]
-        [InlineData("\"hi\"", "hi")]
+        [InlineData(Language.CSharp, "div(123).ToString()", "<div>123</div>")]
+        [InlineData(Language.FSharp, "div.innerHTML(123).ToString()", "<div>123</div>")]
+        [InlineData(Language.CSharp, "display(div(123).ToString());", "<div>123</div>")]
+        //[InlineData(Language.FSharp, "display(div.innerHTML(123).ToString());", "<div>123</div>")]
+        [InlineData(Language.CSharp, "\"hi\"", "hi")]
+        [InlineData(Language.FSharp, "\"hi\"", "hi")]
         public async Task String_is_rendered_as_plain_text(
+            Language language,
             string submission,
             string expectedContent)
         {
-            var kernel = CreateKernel();
+            var kernel = CreateKernel(language);
 
             var result = await kernel.SendAsync(new SubmitCode(submission));
 
@@ -78,12 +89,20 @@ namespace WorkspaceServer.Tests.Kernel
                                    v.Value.ToString().Contains(expectedContent));
         }
 
-        [Fact]
-        public async Task Display_helper_can_be_called_without_specifying_class_name()
+        [Theory]
+        [InlineData(Language.CSharp)]
+        //[InlineData(Language.FSharp)]
+        public async Task Display_helper_can_be_called_without_specifying_class_name(Language language)
         {
-            var kernel = CreateKernel();
+            var kernel = CreateKernel(language);
 
-            await kernel.SendAsync(new SubmitCode("display(b(\"hi!\"));"));
+            var submission = language switch
+            {
+                Language.CSharp => "display(b(\"hi!\"));",
+                Language.FSharp => "display(b.innerHTML(\"hi!\"));",
+            };
+
+            await kernel.SendAsync(new SubmitCode(submission));
 
             var formatted =
                 KernelEvents
@@ -98,13 +117,20 @@ namespace WorkspaceServer.Tests.Kernel
                                    v.Value.ToString().Contains("<b>hi!</b>"));
         }
 
-        [Fact]
-        public async Task Displayed_value_can_be_updated()
+        [Theory]
+        [InlineData(Language.CSharp)]
+        //[InlineData(Language.FSharp)]
+        public async Task Displayed_value_can_be_updated(Language language)
         {
-            var kernel = CreateKernel();
+            var kernel = CreateKernel(language);
 
-            await kernel.SendAsync(new SubmitCode("var d = display(b(\"hello\")); d.Update(b(\"world\"));"));
+            var submission = language switch
+            {
+                Language.CSharp => "var d = display(b(\"hello\")); d.Update(b(\"world\"));",
+                Language.FSharp => "let d = display(b.innerHTML(\"hello\"))\nd.Update(b.innerHTML(\"world\"))",
+            };
 
+            await kernel.SendAsync(new SubmitCode(submission));
 
             KernelEvents
                 .OrderBy(e => e.Timestamp)
@@ -128,12 +154,20 @@ namespace WorkspaceServer.Tests.Kernel
                     v.Value.ToString().Contains("<b>world</b>"));
         }
 
-        [Fact]
-        public async Task Value_display_and_update_are_in_right_order()
+        [Theory]
+        [InlineData(Language.CSharp)]
+        //[InlineData(Language.FSharp)]
+        public async Task Value_display_and_update_are_in_right_order(Language language)
         {
-            var kernel = CreateKernel();
+            var kernel = CreateKernel(language);
 
-            await kernel.SendAsync(new SubmitCode("var d = display(b(\"hello\")); d.Update(b(\"world\"));"));
+            var submission = language switch
+            {
+                Language.CSharp => "var d = display(b(\"hello\")); d.Update(b(\"world\"));",
+                Language.FSharp => "let d = display(b.innerHTML(\"hello\"))\nd.Update(b.innerHTML(\"world\"))",
+            };
+
+            await kernel.SendAsync(new SubmitCode(submission));
 
             var valueEvents =
                 KernelEvents
@@ -146,14 +180,22 @@ namespace WorkspaceServer.Tests.Kernel
             valueEvents.Last().Should().BeOfType<DisplayedValueUpdated>();
         }
 
-        [Fact]
-        public async Task Javascript_helper_emits_string_as_content_within_a_script_element()
+        [Theory]
+        [InlineData(Language.CSharp)]
+        //[InlineData(Language.FSharp)]
+        public async Task Javascript_helper_emits_string_as_content_within_a_script_element(Language language)
         {
-            var kernel = CreateKernel();
+            var kernel = CreateKernel(language);
 
             var scriptContent = "alert('Hello World!');";
 
-            await kernel.SendAsync(new SubmitCode($@"Javascript(""{scriptContent}"");"));
+            var submission = language switch
+            {
+                Language.CSharp => $@"Javascript(""{scriptContent}"");",
+                Language.FSharp => $@"Javascript(""{scriptContent}"")",
+            };
+
+            await kernel.SendAsync(new SubmitCode(submission));
 
             var formatted =
                 KernelEvents

--- a/WorkspaceServer.Tests/Kernel/LanguageKernelRenderingTests.cs
+++ b/WorkspaceServer.Tests/Kernel/LanguageKernelRenderingTests.cs
@@ -63,7 +63,7 @@ namespace WorkspaceServer.Tests.Kernel
         [InlineData(Language.CSharp, "div(123).ToString()", "<div>123</div>")]
         [InlineData(Language.FSharp, "div.innerHTML(123).ToString()", "<div>123</div>")]
         [InlineData(Language.CSharp, "display(div(123).ToString());", "<div>123</div>")]
-        //[InlineData(Language.FSharp, "display(div.innerHTML(123).ToString());", "<div>123</div>")]
+        [InlineData(Language.FSharp, "display(div.innerHTML(123).ToString())", "<div>123</div>")]
         [InlineData(Language.CSharp, "\"hi\"", "hi")]
         [InlineData(Language.FSharp, "\"hi\"", "hi")]
         public async Task String_is_rendered_as_plain_text(
@@ -91,7 +91,7 @@ namespace WorkspaceServer.Tests.Kernel
 
         [Theory]
         [InlineData(Language.CSharp)]
-        //[InlineData(Language.FSharp)]
+        [InlineData(Language.FSharp)]
         public async Task Display_helper_can_be_called_without_specifying_class_name(Language language)
         {
             var kernel = CreateKernel(language);
@@ -119,7 +119,7 @@ namespace WorkspaceServer.Tests.Kernel
 
         [Theory]
         [InlineData(Language.CSharp)]
-        //[InlineData(Language.FSharp)]
+        [InlineData(Language.FSharp)]
         public async Task Displayed_value_can_be_updated(Language language)
         {
             var kernel = CreateKernel(language);
@@ -156,7 +156,7 @@ namespace WorkspaceServer.Tests.Kernel
 
         [Theory]
         [InlineData(Language.CSharp)]
-        //[InlineData(Language.FSharp)]
+        [InlineData(Language.FSharp)]
         public async Task Value_display_and_update_are_in_right_order(Language language)
         {
             var kernel = CreateKernel(language);
@@ -182,7 +182,7 @@ namespace WorkspaceServer.Tests.Kernel
 
         [Theory]
         [InlineData(Language.CSharp)]
-        //[InlineData(Language.FSharp)]
+        [InlineData(Language.FSharp)]
         public async Task Javascript_helper_emits_string_as_content_within_a_script_element(Language language)
         {
             var kernel = CreateKernel(language);

--- a/WorkspaceServer.Tests/Kernel/LanguageKernelTestBase.cs
+++ b/WorkspaceServer.Tests/Kernel/LanguageKernelTestBase.cs
@@ -27,7 +27,7 @@ namespace WorkspaceServer.Tests.Kernel
         {
             var kernelBase = language switch
             {
-                Language.FSharp => (KernelBase) new FSharpKernel().UseDefaultRendering(),
+                Language.FSharp => (KernelBase) new FSharpKernel().UseDefaultRendering().UseKernelHelpers(),
                 Language.CSharp => new CSharpKernel().UseDefaultRendering().UseExtendDirective().UseKernelHelpers(),
                 _ => throw new InvalidOperationException("Unknown language specified")
             };

--- a/WorkspaceServer/Kernel/FSharpKernelExtensions.cs
+++ b/WorkspaceServer/Kernel/FSharpKernelExtensions.cs
@@ -29,6 +29,17 @@ open {typeof(PlotlyChart).Namespace}
             return kernel;
         }
 
+        public static FSharpKernel UseKernelHelpers(
+            this FSharpKernel kernel)
+        {
+            Task.Run(() =>
+                kernel.SendAsync(new SubmitCode($@"
+open {typeof(FSharpKernelHelpers).FullName}
+"))).Wait();
+
+            return kernel;
+        }
+
         private static string ReferenceFromType(Type type)
         {
             return $@"#r ""{type.Assembly.Location.Replace("\\", "\\\\")}""";


### PR DESCRIPTION
~~Some F# tests just work, some have been skipped due to the lack of a global `display` or `Javascript` helper.  Easy enough to add, but I wanted to get this change in, first.~~
All rendering tests work for both C# and F#.