### PR TITLE
allow variable number of arguments to be passed to F#'s version of PocketViewTags `innerHTML()`

### DIFF
--- a/Microsoft.DotNet.Interactive.FSharp.Tests/ApiTests.fs
+++ b/Microsoft.DotNet.Interactive.FSharp.Tests/ApiTests.fs
@@ -27,3 +27,11 @@ type ApiTests() =
     [<Fact>]
     member __.``inner HTML from another tag``() =
         Assert.Equal("<div><a>foo</a></div>", div.innerHTML(a.innerHTML("foo")).ToString())
+
+    [<Fact>]
+    member __.``inner HTML varargs 0``() =
+        Assert.Equal("<div></div>", div.innerHTML().ToString())
+
+    [<Fact>]
+    member __.``inner HTML varargs 2``() =
+        Assert.Equal("<div>ab</div>", div.innerHTML("a", "b").ToString())

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpPocketViewTags.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpPocketViewTags.fs
@@ -3,15 +3,16 @@
 
 namespace Microsoft.DotNet.Interactive.FSharp
 
+open System
 open Microsoft.AspNetCore.Html
 open Microsoft.DotNet.Interactive.Rendering
 
 type FSharpPocketViewTags(p: PocketView) as this =
     override __.ToString() = p.ToString()
-    abstract member innerHTML: obj -> FSharpPocketViewTags
+    abstract member innerHTML: [<ParamArray>] content: obj[] -> FSharpPocketViewTags
     abstract member Item: string * obj -> FSharpPocketViewTags with get
     default __.innerHTML content =
-        p.SetContent([|content|])
+        p.SetContent(content)
         this
     default __.Item
         with get (attribute: string, value: obj) =


### PR DESCRIPTION
This makes F# more like C#.  See the added tests for details.