### PR TITLE
allow F# kernel executions to be cancelled

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,8 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19515.2" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19515.2" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19521.4" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19521.4" />
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
   </ItemGroup>
 

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -3,8 +3,10 @@
 
 namespace Microsoft.DotNet.Interactive.FSharp
 
+open System
 open System.Collections.Generic
 open System.IO
+open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.Scripting
@@ -18,6 +20,7 @@ type FSharpKernel() as this =
 
     let resolvedAssemblies = List<string>()
     let script = new FSharpScript(additionalArgs=[|"/langversion:preview"|])
+    let mutable cancellationTokenSource = new CancellationTokenSource()
 
     do Event.add resolvedAssemblies.Add script.AssemblyReferenceAdded
     do base.AddDisposable(script)
@@ -38,9 +41,10 @@ type FSharpKernel() as this =
             use _ = console.SubscribeToStandardOutput(fun msg -> context.Publish(StandardOutputValueProduced(msg, codeSubmission, FormattedValue.FromObject(msg))))
             use _ = console.SubscribeToStandardError(fun msg -> context.Publish(StandardErrorValueProduced(msg, codeSubmission, FormattedValue.FromObject(msg))))
             resolvedAssemblies.Clear()
+            let tokenSource = cancellationTokenSource
             let result, errors =
                 try
-                    script.Eval(codeSubmission.Code)
+                    script.Eval(codeSubmission.Code, tokenSource.Token)
                 with
                 | ex -> Error(ex), [||]
             for asm in resolvedAssemblies do
@@ -56,18 +60,23 @@ type FSharpKernel() as this =
                 | None -> ()
                 context.Complete()
             | Error(ex) ->
-                let aggregateError = System.String.Join("\n", errors)
-                let reportedException =
-                    match ex with
-                    | :? FsiCompilationException -> CodeSubmissionCompilationErrorException(ex) :> System.Exception
-                    | _ -> ex
-                context.Publish(CommandFailed(reportedException, codeSubmission, aggregateError))
+                if not (tokenSource.IsCancellationRequested) then
+                    let aggregateError = String.Join("\n", errors)
+                    let reportedException =
+                        match ex with
+                        | :? FsiCompilationException -> CodeSubmissionCompilationErrorException(ex) :> Exception
+                        | _ -> ex
+                    context.Publish(CommandFailed(reportedException, codeSubmission, aggregateError))
+                else
+                    context.Publish(new CommandFailed(null, codeSubmission, "Command cancelled"))
         }
 
     let handleCancelCurrentCommand (cancelCurrentCommand: CancelCurrentCommand) (context: KernelInvocationContext) =
         async {
-            let reply = CurrentCommandCancelled(cancelCurrentCommand)
-            context.Publish(reply)
+            cancellationTokenSource.Cancel()
+            cancellationTokenSource.Dispose()
+            cancellationTokenSource <- new CancellationTokenSource()
+            context.Publish(CurrentCommandCancelled(cancelCurrentCommand))
         }
 
     override __.HandleAsync(command: IKernelCommand, _context: KernelInvocationContext): Task =


### PR DESCRIPTION
With dotnet/fsharp#7736 in, F# kernel commands can now be cancelled like C#.