### PR TITLE
load dependencies at extension load time

### DIFF
--- a/MLS.Agent/NativeAssemblyLoadHelper.cs
+++ b/MLS.Agent/NativeAssemblyLoadHelper.cs
@@ -26,13 +26,13 @@ namespace MLS.Agent
 
         public void Handle(string assembly)
         {
-            AppDomain currentDomain = AppDomain.CurrentDomain;
+            var currentDomain = AppDomain.CurrentDomain;
             currentDomain.AssemblyLoad += AssemblyLoaded(assembly);
         }
 
         private AssemblyLoadEventHandler AssemblyLoaded(string assembly)
         {
-            return (object sender, AssemblyLoadEventArgs args) =>
+            return (sender, args) =>
             {
                 if (args.LoadedAssembly.Location == assembly)
                 {

--- a/Microsoft.DotNet.Interactive/Commands/LoadExtensionsInDirectory.cs
+++ b/Microsoft.DotNet.Interactive/Commands/LoadExtensionsInDirectory.cs
@@ -1,17 +1,21 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using MLS.Agent.Tools;
 
 namespace Microsoft.DotNet.Interactive.Commands
 {
     public class LoadExtensionsInDirectory : KernelCommandBase
     {
-        public LoadExtensionsInDirectory(IDirectoryAccessor directory)
+        public LoadExtensionsInDirectory(IDirectoryAccessor directory, IEnumerable<string> additionalDependencies = null)
         {
             Directory = directory;
+            AdditionalDependencies = additionalDependencies ?? Enumerable.Empty<string>();
         }
 
         public IDirectoryAccessor Directory { get; }
+        public IEnumerable<string> AdditionalDependencies { get; }
     }
 }

--- a/Microsoft.DotNet.Interactive/Commands/LoadExtensionsInDirectory.cs
+++ b/Microsoft.DotNet.Interactive/Commands/LoadExtensionsInDirectory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using MLS.Agent.Tools;
-using System.IO;
 
 namespace Microsoft.DotNet.Interactive.Commands
 {

--- a/Microsoft.DotNet.Interactive/IExtensibleKernel.cs
+++ b/Microsoft.DotNet.Interactive/IExtensibleKernel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using MLS.Agent.Tools;
 using System.Threading.Tasks;
 
@@ -8,6 +9,6 @@ namespace Microsoft.DotNet.Interactive
 {
     public interface IExtensibleKernel
     {
-        Task LoadExtensionsFromDirectory(IDirectoryAccessor directory, KernelInvocationContext invocationContext);
+        Task LoadExtensionsFromDirectory(IDirectoryAccessor directory, KernelInvocationContext invocationContext, IEnumerable<string> additionalDependencies = null);
     }
 }

--- a/Microsoft.DotNet.Interactive/IExtensibleKernel.cs
+++ b/Microsoft.DotNet.Interactive/IExtensibleKernel.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using MLS.Agent.Tools;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Interactive
 {
     public interface IExtensibleKernel
     {
-        public Task LoadExtensionsInDirectory(IDirectoryAccessor directory, KernelInvocationContext invocationContext);
+        Task LoadExtensionsInDirectory(IDirectoryAccessor directory, KernelInvocationContext invocationContext);
     }
 }

--- a/Microsoft.DotNet.Interactive/IExtensibleKernel.cs
+++ b/Microsoft.DotNet.Interactive/IExtensibleKernel.cs
@@ -8,6 +8,6 @@ namespace Microsoft.DotNet.Interactive
 {
     public interface IExtensibleKernel
     {
-        Task LoadExtensionsInDirectory(IDirectoryAccessor directory, KernelInvocationContext invocationContext);
+        Task LoadExtensionsFromDirectory(IDirectoryAccessor directory, KernelInvocationContext invocationContext);
     }
 }

--- a/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.Interactive
             {
                 if (context.HandlingKernel is IExtensibleKernel extensibleKernel)
                 {
-                    await extensibleKernel.LoadExtensionsInDirectory(loadExtensionsInDirectory.Directory, context);
+                    await extensibleKernel.LoadExtensionsFromDirectory(loadExtensionsInDirectory.Directory, context);
                 }
                 else
                 {

--- a/Microsoft.DotNet.Interactive/KernelBase.cs
+++ b/Microsoft.DotNet.Interactive/KernelBase.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.Interactive
             {
                 if (context.HandlingKernel is IExtensibleKernel extensibleKernel)
                 {
-                    await extensibleKernel.LoadExtensionsFromDirectory(loadExtensionsInDirectory.Directory, context);
+                    await extensibleKernel.LoadExtensionsFromDirectory(loadExtensionsInDirectory.Directory, context, loadExtensionsInDirectory.AdditionalDependencies);
                 }
                 else
                 {

--- a/Microsoft.DotNet.Interactive/KernelExtensionLoader.cs
+++ b/Microsoft.DotNet.Interactive/KernelExtensionLoader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
 using System;
 using System.IO;
@@ -28,6 +27,7 @@ namespace Microsoft.DotNet.Interactive
             }
 
             var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyFile.FullName);
+           
             var extensionTypes = assembly
                                    .ExportedTypes
                                    .Where(t => t.CanBeInstantiated() && typeof(IKernelExtension).IsAssignableFrom(t))

--- a/WorkspaceServer/Kernel/CSharpKernel.cs
+++ b/WorkspaceServer/Kernel/CSharpKernel.cs
@@ -346,10 +346,11 @@ namespace WorkspaceServer.Kernel
             }
         }
 
-        public async Task LoadExtensionsFromDirectory(IDirectoryAccessor directory, KernelInvocationContext context)
+        public async Task LoadExtensionsFromDirectory(IDirectoryAccessor directory, KernelInvocationContext context,
+            IEnumerable<string> additionalDependencies = null)
         {
             var extensionsDirectory = directory.GetDirectoryAccessorForRelativePath(_assemblyExtensionsPath);
-            await new KernelExtensionLoader().LoadFromAssembliesInDirectory(extensionsDirectory, context.HandlingKernel, context);
+            await new KernelExtensionLoader().LoadFromAssembliesInDirectory(extensionsDirectory, context.HandlingKernel, context, additionalDependencies);
         }
         
         private bool HasReturnValue =>

--- a/WorkspaceServer/Kernel/CSharpKernel.cs
+++ b/WorkspaceServer/Kernel/CSharpKernel.cs
@@ -346,7 +346,7 @@ namespace WorkspaceServer.Kernel
             }
         }
 
-        public async Task LoadExtensionsInDirectory(IDirectoryAccessor directory, KernelInvocationContext context)
+        public async Task LoadExtensionsFromDirectory(IDirectoryAccessor directory, KernelInvocationContext context)
         {
             var extensionsDirectory = directory.GetDirectoryAccessorForRelativePath(_assemblyExtensionsPath);
             await new KernelExtensionLoader().LoadFromAssembliesInDirectory(extensionsDirectory, context.HandlingKernel, context);

--- a/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
+++ b/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
@@ -101,11 +101,6 @@ using static {typeof(Microsoft.DotNet.Interactive.Kernel).FullName};
                             }
                         }
 
-                        foreach (var reference in result.References)
-                        {
-                           AssemblyLoadContext.Default.LoadFromAssemblyPath(reference.Display);
-                        }
-
                         kernel.AddMetadataReferences(result.References);
 
                         context.Publish(new DisplayedValueProduced($"Successfully added reference to package {package.PackageName}, version {result.InstalledVersion}",
@@ -114,7 +109,7 @@ using static {typeof(Microsoft.DotNet.Interactive.Kernel).FullName};
                         context.Publish(new NuGetPackageAdded(addPackage, package));
 
                         var nugetPackageDirectory = new FileSystemDirectoryAccessor(await restoreContext.GetDirectoryForPackage(package.PackageName));
-                        await context.HandlingKernel.SendAsync(new LoadExtensionsInDirectory(nugetPackageDirectory));
+                        await context.HandlingKernel.SendAsync(new LoadExtensionsInDirectory(nugetPackageDirectory, result.References.Select(r => r.Display)));
                     }
                     else
                     {

--- a/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
+++ b/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;
+using System.Runtime.Loader;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -98,6 +99,8 @@ using static {typeof(Microsoft.DotNet.Interactive.Kernel).FullName};
                             {
                                 helper?.Handle(peRef.FilePath);
                             }
+
+                            AssemblyLoadContext.Default.LoadFromAssemblyPath(reference.Display);
                         }
 
                         kernel.AddMetadataReferences(result.References);

--- a/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
+++ b/WorkspaceServer/Kernel/CSharpKernelExtensions.cs
@@ -99,8 +99,11 @@ using static {typeof(Microsoft.DotNet.Interactive.Kernel).FullName};
                             {
                                 helper?.Handle(peRef.FilePath);
                             }
+                        }
 
-                            AssemblyLoadContext.Default.LoadFromAssemblyPath(reference.Display);
+                        foreach (var reference in result.References)
+                        {
+                           AssemblyLoadContext.Default.LoadFromAssemblyPath(reference.Display);
                         }
 
                         kernel.AddMetadataReferences(result.References);

--- a/WorkspaceServer/Kernel/KernelExtensionLoaderExtensions.cs
+++ b/WorkspaceServer/Kernel/KernelExtensionLoaderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Interactive;
 using Task = System.Threading.Tasks.Task;
@@ -11,15 +12,19 @@ namespace WorkspaceServer.Kernel
 {
     public static class KernelExtensionLoaderExtensions
     {
-        public static async Task LoadFromAssembliesInDirectory(this KernelExtensionLoader loader, IDirectoryAccessor directory, IKernel kernel, KernelInvocationContext context)
+        public static async Task LoadFromAssembliesInDirectory(this KernelExtensionLoader loader,
+            IDirectoryAccessor directory, IKernel kernel, KernelInvocationContext context,
+            IEnumerable<string> additionalDependencies = null)
         {
             if (directory.RootDirectoryExists())
             {
                 context.Publish(new DisplayedValueProduced($"Loading kernel extensions in directory {directory.GetFullyQualifiedRoot().FullName}", context.Command));
                 var extensionDlls = directory.GetAllFiles().Where(file => file.Extension == ".dll").Select(file => directory.GetFullyQualifiedFilePath(file));
+
+                
                 foreach (var extensionDll in extensionDlls)
                 {
-                    await loader.LoadFromAssembly(extensionDll, kernel, context);
+                    await loader.LoadFromAssembly(extensionDll, kernel, context, additionalDependencies);
                 }
 
                 context.Publish(new DisplayedValueProduced($"Loaded kernel extensions in directory {directory.GetFullyQualifiedRoot().FullName}", context.Command));

--- a/WorkspaceServer/Kernel/KernelExtensionLoaderExtensions.cs
+++ b/WorkspaceServer/Kernel/KernelExtensionLoaderExtensions.cs
@@ -11,7 +11,7 @@ namespace WorkspaceServer.Kernel
 {
     public static class KernelExtensionLoaderExtensions
     {
-         public static async Task LoadFromAssembliesInDirectory(this KernelExtensionLoader loader, IDirectoryAccessor directory, IKernel kernel, KernelInvocationContext context)
+        public static async Task LoadFromAssembliesInDirectory(this KernelExtensionLoader loader, IDirectoryAccessor directory, IKernel kernel, KernelInvocationContext context)
         {
             if (directory.RootDirectoryExists())
             {


### PR DESCRIPTION
loading nuget packages only load references to script options.  Extension loading requires assemblies to be available via the AssemblyLoadContext