### PR TITLE
properly format non-generic `IDictionary`

### DIFF
--- a/Microsoft.DotNet.Interactive.Rendering.Tests/DictionaryTypes.cs
+++ b/Microsoft.DotNet.Interactive.Rendering.Tests/DictionaryTypes.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.DotNet.Interactive.Rendering.Tests
+{
+    /// <summary>
+    /// Implements <see cref="IDictionary{,}" />, but not <see cref="IDictionary"/>.
+    /// </summary>
+    internal class GenericDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private Dictionary<TKey, TValue> _values = new Dictionary<TKey, TValue>();
+
+        public TValue this[TKey key] { get => ((IDictionary<TKey, TValue>)_values)[key]; set => ((IDictionary<TKey, TValue>)_values)[key] = value; }
+
+        public ICollection<TKey> Keys => ((IDictionary<TKey, TValue>)_values).Keys;
+
+        public ICollection<TValue> Values => ((IDictionary<TKey, TValue>)_values).Values;
+
+        public int Count => ((IDictionary<TKey, TValue>)_values).Count;
+
+        public bool IsReadOnly => ((IDictionary<TKey, TValue>)_values).IsReadOnly;
+
+        public void Add(TKey key, TValue value)
+        {
+            ((IDictionary<TKey, TValue>)_values).Add(key, value);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            ((IDictionary<TKey, TValue>)_values).Add(item);
+        }
+
+        public void Clear()
+        {
+            ((IDictionary<TKey, TValue>)_values).Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ((IDictionary<TKey, TValue>)_values).Contains(item);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return ((IDictionary<TKey, TValue>)_values).ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ((IDictionary<TKey, TValue>)_values).CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return ((IDictionary<TKey, TValue>)_values).GetEnumerator();
+        }
+
+        public bool Remove(TKey key)
+        {
+            return ((IDictionary<TKey, TValue>)_values).Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return ((IDictionary<TKey, TValue>)_values).Remove(item);
+        }
+
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+        {
+            return ((IDictionary<TKey, TValue>)_values).TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary<TKey, TValue>)_values).GetEnumerator();
+        }
+    }
+
+    /// <summary>
+    /// Implements <see cref="IDictionary" />, but not <see cref="IDictionary{,}"/>.
+    /// </summary>
+    internal class NonGenericDictionary : IDictionary
+    {
+        private Dictionary<object, object> _values = new Dictionary<object, object>();
+
+        public object this[object key] { get => ((IDictionary)_values)[key]; set => ((IDictionary)_values)[key] = value; }
+
+        public bool IsFixedSize => ((IDictionary)_values).IsFixedSize;
+
+        public bool IsReadOnly => ((IDictionary)_values).IsReadOnly;
+
+        public ICollection Keys => ((IDictionary)_values).Keys;
+
+        public ICollection Values => ((IDictionary)_values).Values;
+
+        public int Count => ((IDictionary)_values).Count;
+
+        public bool IsSynchronized => ((IDictionary)_values).IsSynchronized;
+
+        public object SyncRoot => ((IDictionary)_values).SyncRoot;
+
+        public void Add(object key, object value)
+        {
+            ((IDictionary)_values).Add(key, value);
+        }
+
+        public void Clear()
+        {
+            ((IDictionary)_values).Clear();
+        }
+
+        public bool Contains(object key)
+        {
+            return ((IDictionary)_values).Contains(key);
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            ((IDictionary)_values).CopyTo(array, index);
+        }
+
+        public IDictionaryEnumerator GetEnumerator()
+        {
+            return ((IDictionary)_values).GetEnumerator();
+        }
+
+        public void Remove(object key)
+        {
+            ((IDictionary)_values).Remove(key);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary)_values).GetEnumerator();
+        }
+    }
+}

--- a/Microsoft.DotNet.Interactive.Rendering.Tests/HtmlFormatterTests.cs
+++ b/Microsoft.DotNet.Interactive.Rendering.Tests/HtmlFormatterTests.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
-using FluentAssertions;
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 
 namespace Microsoft.DotNet.Interactive.Rendering.Tests
@@ -226,11 +227,32 @@ namespace Microsoft.DotNet.Interactive.Rendering.Tests
             }
 
             [Fact]
-            public void It_formats_dictionaries_as_tables_with_the_key_on_the_y_axis()
+            public void It_formats_generic_dictionaries_that_arent_non_generic_as_tables_with_the_key_on_the_y_axis()
             {
                 var writer = new StringWriter();
 
-                var instance = new Dictionary<string, EntityId>
+                IDictionary<string, EntityId> instance = new GenericDictionary<string, EntityId>
+                {
+                    { "first", new EntityId("entity one", "123") },
+                    { "second", new EntityId("entity two", "456") }
+                };
+
+                var formatter = HtmlFormatter.Create(instance.GetType());
+
+                formatter.Format(instance, writer);
+
+                writer.ToString()
+                      .Should()
+                      .Be(
+                          "<table><thead><tr><th><i>key</i></th><th>TypeName</th><th>Id</th></tr></thead><tbody><tr><td>first</td><td>entity one</td><td>123</td></tr><tr><td>second</td><td>entity two</td><td>456</td></tr></tbody></table>");
+            }
+
+            [Fact]
+            public void It_formats_non_generic_dictionaries_that_arent_generic_as_tables_with_the_key_on_the_y_axis()
+            {
+                var writer = new StringWriter();
+
+                IDictionary instance = new NonGenericDictionary
                 {
                     { "first", new EntityId("entity one", "123") },
                     { "second", new EntityId("entity two", "456") }


### PR DESCRIPTION
The sequence formatter was incorrectly assuming that `IDictionary<TKey, TValue>` necessarily implements `IDictionary`, which is not the case (however, `IEnumerable<T>` **does** necessarily implement `IEnumerable` and both `IDictionary` and `IDictionary<TKey, TValue>` implement `IEnumerable`, and `IDictionary<TKey, TValue>` implements `IEnumerable<KeyValuePair<TKey, TValue>>`.  I won't go into the fact that `IDictionary<TKey, TValue>` returns `ICollection<TKey>` for its `.Keys` property and `IDictionary` returns `ICollection` for its `.Keys` property, but `ICollection<T>` **doesn't** implement `ICollection`.  Clear?)

Fixes #554.