### PR TITLE
do not produce ExecuteResult if the ReturnValueProduced events raw value is of type DisplayedValue

### DIFF
--- a/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter.Tests/ExecuteRequestHandlerTests.cs
@@ -96,6 +96,23 @@ namespace Microsoft.DotNet.Interactive.Jupyter.Tests
             JupyterMessageSender.PubSubMessages.Should().Contain(r => r is DisplayData);
         }
 
+
+        [Theory]
+        [InlineData(Language.CSharp)]
+        [InlineData(Language.FSharp)]
+        public async Task _does_not_send_ExecuteResult_message_when_evaluating_display_value(Language language)
+        {
+            var scheduler = CreateScheduler();
+            SetKernelLanguage(language);
+            var request = Envelope.Create(new ExecuteRequest("display(2+2)"));
+            var context = new JupyterRequestContext(JupyterMessageSender, request, "id");
+            await scheduler.Schedule(context);
+
+            await context.Done().Timeout(20.Seconds());
+
+            JupyterMessageSender.PubSubMessages.Should().NotContain(r => r is ExecuteResult);
+        }
+
         [Fact]
         public async Task sends_Stream_message_on_StandardOutputValueProduced()
         {

--- a/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
+++ b/Microsoft.DotNet.Interactive.Jupyter/ExecuteRequestHandler.cs
@@ -103,6 +103,11 @@ namespace Microsoft.DotNet.Interactive.Jupyter
             Envelope request,
             IJupyterMessageSender jupyterMessageSender)
         {
+            if (displayEvent is ReturnValueProduced && displayEvent.Value is DisplayedValue)
+            {
+                return;
+            }
+
             var transient = CreateTransient(displayEvent.ValueId);
 
             var formattedValues = displayEvent

--- a/Microsoft.DotNet.Interactive/KernelStreamClient.cs
+++ b/Microsoft.DotNet.Interactive/KernelStreamClient.cs
@@ -80,13 +80,17 @@ namespace Microsoft.DotNet.Interactive
             }
         }
 
-        private void Write(IKernelEvent e, int id)
+        private void Write(IKernelEvent kernelEvent, int correlationId)
         {
+            if (kernelEvent is ReturnValueProduced rvp && rvp.Value is DisplayedValue)
+            {
+                return;
+            }
             var wrapper = new StreamKernelEvent
             {
-                Id = id,
-                Event = e,
-                EventType = e.GetType().Name
+                Id = correlationId,
+                Event = kernelEvent,
+                EventType = kernelEvent.GetType().Name
             };
             var serialized = wrapper.Serialize();
             _output.Write(serialized);

--- a/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
+++ b/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
@@ -139,7 +139,7 @@ namespace WorkspaceServer.Tests.Kernel
             await _kernelClient.Start();
 
             var gate = _io.OutputStream
-                .TakeUntilCommandHandled(1.Seconds());
+                .TakeUntilCommandHandled();
 
             _io.WriteToInput(new SubmitCode(@"var x = 123;"), 0);
 
@@ -162,7 +162,7 @@ namespace WorkspaceServer.Tests.Kernel
         {
             await _kernelClient.Start();
             var gate = _io.OutputStream
-                .TakeUntilCommandHandled(1.Seconds());
+                .TakeUntilCommandHandled();
 
             _io.WriteToInput(new SubmitCode("display(1543); display(4567);"), 0);
 
@@ -177,7 +177,7 @@ namespace WorkspaceServer.Tests.Kernel
         {
             await _kernelClient.Start();
             var gate = _io.OutputStream
-                .TakeUntilCommandHandled(1.Seconds());
+                .TakeUntilCommandHandled();
             _io.WriteToInput(new SubmitCode("display(1543)"), 0);
 
             await gate;
@@ -190,10 +190,11 @@ namespace WorkspaceServer.Tests.Kernel
         public async Task Kernel_client_surfaces_json_errors()
         {
             await _kernelClient.Start();
-
+            var gate = _io.OutputStream
+                .TakeUntilCommandParseFailure();
             _io.WriteToInput("{ hello");
             
-            await Task.Delay(1.Seconds());
+            await gate;
 
             this.Assent(string.Join("\n", _events.Select(e => e.ToString(Formatting.None))), _configuration);
         }
@@ -203,7 +204,7 @@ namespace WorkspaceServer.Tests.Kernel
         {
             await _kernelClient.Start();
             var gate = _io.OutputStream
-                .TakeUntilCommandFailed(1.Seconds());
+                .TakeUntilCommandFailed();
 
             _io.WriteToInput(new SubmitCode(@"var a = 12"), 0);
 
@@ -246,7 +247,7 @@ namespace WorkspaceServer.Tests.Kernel
             await _kernelClient.Start();
 
             var gate = _io.OutputStream
-                .TakeUntilCommandHandled(1.Minutes());
+                .TakeUntilCommandHandled(10.Minutes());
 
             _io.WriteToInput(new SubmitCode(@"#r ""nuget:Microsoft.Spark, 0.4.0"""), 0);
 

--- a/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
+++ b/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
@@ -172,6 +172,22 @@ namespace WorkspaceServer.Tests.Kernel
         }
 
         [Fact]
+        public async Task Client_does_not_stream_ReturnValueProduced_events_if_the_value_is_DisplayedValue()
+        {
+            await _kernelClient.Start();
+
+            _io.WriteToInput(new SubmitCode("display(1543)"), 0);
+
+            var events = _events
+                .TakeUntil(DateTimeOffset.Now.Add(2.Seconds()))
+                .ToEnumerable()
+                .ToList();
+
+            events.Should()
+                .NotContain(e => e["eventType"].Value<string>() == nameof(ReturnValueProduced));
+        }
+
+        [Fact]
         public async Task Kernel_client_surfaces_json_errors()
         {
             await _kernelClient.Start();

--- a/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
+++ b/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
@@ -219,21 +219,21 @@ namespace WorkspaceServer.Tests.Kernel
         {
             await _kernelClient.Start();
             var gate = _io.OutputStream
-                .TakeUntilCommandHandled(2.Seconds());
+                .TakeUntilCommandHandled();
             _io.WriteToInput(new SubmitCode(@"Func<int> func = () => 1;"), 0);
             await gate;
 
             gate = _io.OutputStream
-                .TakeUntilEvent<ReturnValueProduced>(2.Seconds());
+                .TakeUntilEvent<ReturnValueProduced>();
             _io.WriteToInput(new SubmitCode(@"func()"), 1);
             await gate;
 
             gate = _io.OutputStream
-                .TakeUntilEvent<ReturnValueProduced>(2.Seconds());
+                .TakeUntilEvent<ReturnValueProduced>();
             _io.WriteToInput(new SubmitCode(@"func"), 2);
             await gate;
 
-            await Task.Delay(1.Seconds());
+            await Task.Delay(2.Seconds());
             
             _events
                 .Count(e => e["eventType"].Value<string>() == nameof(ReturnValueProduced))

--- a/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
+++ b/WorkspaceServer.Tests/Kernel/KernelClientTests.cs
@@ -15,6 +15,7 @@ using FluentAssertions.Extensions;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Events;
+using Microsoft.DotNet.Interactive.Tests;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Pocket;
@@ -28,7 +29,7 @@ namespace WorkspaceServer.Tests.Kernel
     {
         private readonly Configuration _configuration;
         private readonly KernelStreamClient _kernelClient;
-        private readonly IObservable<JObject> _events;
+        private readonly SubscribedList<JObject> _events;
         private readonly IOStreams _io;
         private readonly ITestOutputHelper _output;
         private readonly CompositeDisposable _disposables = new CompositeDisposable();
@@ -122,7 +123,8 @@ namespace WorkspaceServer.Tests.Kernel
 
             _events = _io.OutputStream
                          .Where(s => !string.IsNullOrWhiteSpace(s))
-                         .Select(JObject.Parse);
+                         .Select(JObject.Parse)
+                         .ToSubscribedList();
 
             _disposables.Add(_kernelClient);
             _disposables.Add(_output.SubscribeToPocketLogger());
@@ -136,15 +138,15 @@ namespace WorkspaceServer.Tests.Kernel
         {
             await _kernelClient.Start();
 
+            var gate = _io.OutputStream
+                .TakeUntilCommandHandled(1.Seconds());
+
             _io.WriteToInput(new SubmitCode(@"var x = 123;"), 0);
 
+            await gate;
+
             var events = _events
-                         .TakeUntilCommandHandled()
-                         .LastAsync()
-                         .Timeout(20.Seconds())
-                         .Select(e => e.ToString(Formatting.None))
-                         .ToEnumerable()
-                         .ToList();
+                         .Select(e => e.ToString(Formatting.None));
 
             var expectedEvents = new List<string> {
                 IOStreams.ToStreamKernelEvent(new CommandHandled(new SubmitCode(@"var x = 123;")), 0).Serialize(),
@@ -159,15 +161,14 @@ namespace WorkspaceServer.Tests.Kernel
         public async Task Kernel_produces_only_commandHandled_for_root_command()
         {
             await _kernelClient.Start();
+            var gate = _io.OutputStream
+                .TakeUntilCommandHandled(1.Seconds());
 
             _io.WriteToInput(new SubmitCode("display(1543); display(4567);"), 0);
 
-            var events = _events
-                .TakeUntil(DateTimeOffset.Now.Add(2.Seconds()))
-                .ToEnumerable()
-                .ToList();
+            await gate;
 
-            events.Should()
+            _events.Should()
                 .ContainSingle(e => e["eventType"].Value<string>() == nameof(CommandHandled));
         }
 
@@ -175,15 +176,13 @@ namespace WorkspaceServer.Tests.Kernel
         public async Task Client_does_not_stream_ReturnValueProduced_events_if_the_value_is_DisplayedValue()
         {
             await _kernelClient.Start();
-
+            var gate = _io.OutputStream
+                .TakeUntilCommandHandled(1.Seconds());
             _io.WriteToInput(new SubmitCode("display(1543)"), 0);
 
-            var events = _events
-                .TakeUntil(DateTimeOffset.Now.Add(2.Seconds()))
-                .ToEnumerable()
-                .ToList();
+            await gate;
 
-            events.Should()
+            _events.Should()
                 .NotContain(e => e["eventType"].Value<string>() == nameof(ReturnValueProduced));
         }
 
@@ -193,31 +192,24 @@ namespace WorkspaceServer.Tests.Kernel
             await _kernelClient.Start();
 
             _io.WriteToInput("{ hello");
+            
+            await Task.Delay(1.Seconds());
 
-            var events = _events
-                .TakeUntilCommandParseFailure()
-                .Timeout(DateTimeOffset.Now.Add(10.Seconds()))
-                .ToEnumerable()
-                .ToList();
-
-            this.Assent(string.Join("\n", events.Select(e => e.ToString(Formatting.None))), _configuration);
+            this.Assent(string.Join("\n", _events.Select(e => e.ToString(Formatting.None))), _configuration);
         }
 
         [Fact]
         public async Task Kernel_client_surfaces_code_submission_Errors()
         {
             await _kernelClient.Start();
+            var gate = _io.OutputStream
+                .TakeUntilCommandFailed(1.Seconds());
 
             _io.WriteToInput(new SubmitCode(@"var a = 12"), 0);
 
-            var termination = new Subject<int>();
-            var events = _events
-                .TakeUntilCommandFailed()
-                .Timeout(DateTimeOffset.Now.Add(10.Seconds()))
-                .ToEnumerable()
-                .ToList();
+            await gate;
 
-            events.Should()
+            _events.Should()
                 .Contain(e => e["eventType"].Value<string>() == nameof(IncompleteCodeSubmissionReceived));
         }
 
@@ -225,31 +217,27 @@ namespace WorkspaceServer.Tests.Kernel
         public async Task Kernel_client_eval_function_instances()
         {
             await _kernelClient.Start();
-
+            var gate = _io.OutputStream
+                .TakeUntilCommandHandled(2.Seconds());
             _io.WriteToInput(new SubmitCode(@"Func<int> func = () => 1;"), 0);
-            
-            await Task.Delay(2.Seconds());
+            await gate;
 
+            gate = _io.OutputStream
+                .TakeUntilEvent<ReturnValueProduced>(2.Seconds());
             _io.WriteToInput(new SubmitCode(@"func()"), 1);
+            await gate;
+
+            gate = _io.OutputStream
+                .TakeUntilEvent<ReturnValueProduced>(2.Seconds());
             _io.WriteToInput(new SubmitCode(@"func"), 2);
+            await gate;
+
+            await Task.Delay(1.Seconds());
             
-
-            var commandHandled = 0;
-            var events = _events
-                .Do(e =>
-                {
-                    if (e["eventType"].Value<string>() == nameof(CommandHandled))
-                    {
-                        commandHandled++;
-                    }
-                })
-                .TakeWhile(_ => commandHandled < 3)
-                .TakeUntil(DateTimeOffset.Now.Add(1.Minutes()))
-                .ToEnumerable()
-                .ToList();
-
-            events.Where(e => e["eventType"].Value<string>() == nameof(ReturnValueProduced)).Should()
-                .HaveCount(2);
+            _events
+                .Count(e => e["eventType"].Value<string>() == nameof(ReturnValueProduced))
+                .Should()
+                .Be(2);
         }
 
         [Fact]
@@ -257,15 +245,14 @@ namespace WorkspaceServer.Tests.Kernel
         {
             await _kernelClient.Start();
 
+            var gate = _io.OutputStream
+                .TakeUntilCommandHandled(1.Minutes());
+
             _io.WriteToInput(new SubmitCode(@"#r ""nuget:Microsoft.Spark, 0.4.0"""), 0);
 
-            var events = _events
-                .TakeUntilCommandHandled()
-                .Timeout(1.Minutes())
-                .ToEnumerable()
-                .ToList();
+            await gate;
 
-            events.Should().Contain(e => e["eventType"].Value<string>() == nameof(NuGetPackageAdded));
+            _events.Should().Contain(e => e["eventType"].Value<string>() == nameof(NuGetPackageAdded));
         }
 
         public void Dispose()

--- a/WorkspaceServer.Tests/Kernel/ObservableExtensions.cs
+++ b/WorkspaceServer.Tests/Kernel/ObservableExtensions.cs
@@ -54,12 +54,17 @@ namespace WorkspaceServer.Tests.Kernel
                         termination.OnNext(Unit.Default);
                     }
                 })
-                .Timeout(timeout ?? 10.Minutes());
+                .Timeout(timeout ?? 1.Seconds());
         }
 
         public static IObservable<JObject> TakeUntilCommandHandled(this IObservable<JObject> source, TimeSpan? timeout = null)
         {
             return source.TakeUntilEvent<CommandHandled>(timeout);
+        }
+
+        public static IObservable<JObject> TakeUntilCommandParseFailure(this IObservable<string> source, TimeSpan? timeout = null)
+        {
+            return source.TakeUntilEvent<CommandParseFailure>(timeout);
         }
 
         public static IObservable<JObject> TakeUntilCommandParseFailure(this IObservable<JObject> source, TimeSpan? timeout = null)

--- a/WorkspaceServer.Tests/Kernel/ObservableExtensions.cs
+++ b/WorkspaceServer.Tests/Kernel/ObservableExtensions.cs
@@ -54,7 +54,7 @@ namespace WorkspaceServer.Tests.Kernel
                         termination.OnNext(Unit.Default);
                     }
                 })
-                .Timeout(timeout ?? 1.Seconds());
+                .Timeout(timeout ?? 10.Seconds());
         }
 
         public static IObservable<JObject> TakeUntilCommandHandled(this IObservable<JObject> source, TimeSpan? timeout = null)

--- a/WorkspaceServer.Tests/Kernel/ObservableExtensions.cs
+++ b/WorkspaceServer.Tests/Kernel/ObservableExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using FluentAssertions.Extensions;
 using Microsoft.DotNet.Interactive.Events;
 using Newtonsoft.Json.Linq;
 
@@ -45,19 +46,15 @@ namespace WorkspaceServer.Tests.Kernel
         public static IObservable<JObject> TakeUntilEvent<T>(this IObservable<JObject> source, TimeSpan? timeout = null) where T : IKernelEvent
         {
             var termination = new Subject<Unit>();
-            var stream =  source.TakeUntil(termination)
+            return source.TakeUntil(termination)
                 .Do(e =>
                 {
                     if (e["eventType"].Value<string>() == typeof(T).Name)
                     {
                         termination.OnNext(Unit.Default);
                     }
-                });
-            if (timeout != null)
-            {
-                stream = stream.Timeout(timeout.Value);
-            }
-            return stream;
+                })
+                .Timeout(timeout ?? 10.Minutes());
         }
 
         public static IObservable<JObject> TakeUntilCommandHandled(this IObservable<JObject> source, TimeSpan? timeout = null)


### PR DESCRIPTION
Addressing issue #558 when the cell evaluates to a `DisplayedValue` the object should not be printed