### PR TITLE
display F# package installation status

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,8 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19521.4" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19521.4" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19551.5" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19551.5" />
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
   </ItemGroup>
 

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -10,6 +10,7 @@ open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.Scripting
+open FSharp.DependencyManager
 open Microsoft.DotNet.Interactive
 open Microsoft.DotNet.Interactive.Commands
 open Microsoft.DotNet.Interactive.Events
@@ -25,8 +26,50 @@ type FSharpKernel() =
     do Event.add resolvedAssemblies.Add script.AssemblyReferenceAdded
     do base.AddDisposable(script)
 
+    let messageMap = Dictionary<string, string>()
+
+    let parseReference text =
+        FSharpDependencyManager.parsePackageReference [text]
+        |> fst
+        |> List.head
+
+    let packageMessage dependency =
+        let versionText = match dependency.Version with
+                          | "*" -> ""
+                          | _ -> ", version " + dependency.Version
+        "Installing package " + dependency.Include + versionText + "."
+
     let handleSubmitCode (codeSubmission: SubmitCode) (context: KernelInvocationContext) =
         async {
+
+            script.DependencyAdding
+            |> Event.add (fun (key, referenceText) ->
+                if key = "nuget" then
+                    let reference = parseReference referenceText
+                    let message = packageMessage reference
+                    let key = message
+                    messageMap.[key] <- message
+                    context.Publish(DisplayedValueProduced(message, context.Command, valueId=key))
+                ())
+
+            script.DependencyAdded
+            |> Event.add (fun (key, referenceText) ->
+                if key = "nuget" then
+                    let reference = parseReference referenceText
+                    let key = packageMessage reference
+                    let message = messageMap.[key] + "done!"
+                    context.Publish(DisplayedValueUpdated(message, key))
+                ())
+
+            script.DependencyFailed
+            |> Event.add (fun (key, referenceText) ->
+                if key = "nuget" then
+                    let reference = parseReference referenceText
+                    let key = packageMessage reference
+                    let message = messageMap.[key] + "failed!"
+                    context.Publish(DisplayedValueUpdated(message, key))
+                ())
+
             let codeSubmissionReceived = CodeSubmissionReceived(codeSubmission.Code, codeSubmission)
             context.Publish(codeSubmissionReceived)
             use! console = ConsoleOutput.Capture() |> Async.AwaitTask

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -59,6 +59,9 @@ type FSharpKernel() =
                     let key = packageMessage reference
                     let message = messageMap.[key] + "done!"
                     context.Publish(DisplayedValueUpdated(message, key))
+                    let packageRef = if reference.Version = "*" then NugetPackageReference(reference.Include)
+                                     else NugetPackageReference(reference.Include, packageVersion=reference.Version)
+                    context.Publish(NuGetPackageAdded(AddNugetPackage(packageRef), packageRef))
                 ())
 
             script.DependencyFailed


### PR DESCRIPTION
Consume events added in dotnet/fsharp#7796 to display package installation status.

![image](https://user-images.githubusercontent.com/926281/68074345-25d1cf80-fd57-11e9-9e91-fc0811c3c8d6.png)
