### PR TITLE
Set DotNetUseShippingVersions.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,8 @@
   <Import Project="eng\targets\NuGet.targets" />
 
   <PropertyGroup>
+    <!-- Always use shipping version instead of dummy version -->
+    <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- private repo, don't do source-link -->
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <EnableSourceLink>false</EnableSourceLink>


### PR DESCRIPTION
This disables the `42.42.42.42` assembly versions when building locally. Instead, a date based version is used with a `-0` suffix.

This allows for locally built assemblies to replace official built assemblies in an install folder. This is useful for debugging (can replace a release binary with a debug binary), and for quick prototyping without having to rebuild the whole dotnet-try package and uninstall-reinstall.

Let me know if you'd like this fix or not. I found it useful myself so I could stick a Debug assembly in my local install. Some repos use this setting, some repos don't.