### PR TITLE
fix FSharp notebook-example syntax

### DIFF
--- a/NotebookExamples/fsharp/Samples/Repo Statistics.ipynb
+++ b/NotebookExamples/fsharp/Samples/Repo Statistics.ipynb
@@ -52,8 +52,8 @@
     }
    ],
    "source": [
-    "//var tokenAuth = new Credentials(\"YOUR TOKEN\");\n",
-    "//gitHubClient.Credentials = tokenAuth;"
+    "//let tokenAuth = Credentials(\"YOUR TOKEN\")\n",
+    "//gitHubClient.Credentials = tokenAuth"
    ]
   },
   {


### PR DESCRIPTION
It seems to be still CSharp syntax in code where comment outed.