### PR TITLE
README.md: Fixed typo and follow link (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Try .NET <img src ="https://user-images.githubusercontent.com/2546640/56708992-deee8780-66ec-11e9-9991-eb85abb1d10a.png" width="80px" alt="dotnet bot in space" align ="right">
-|| [**Contribution Guidelines**](#contribution) || [**Table of content**](#table-of-contents) || [**Customers & Partners**](#customers--partners) ||
+|| [**Contribution Guidelines**](#contribution-guidelines) || [**Table of contents**](#table-of-contents) || [**Customers & Partners**](#customers--partners) ||
 
 ![Try_.NET Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
 


### PR DESCRIPTION
- Changed 'Table of content' to 'Table of contents'.
- Clicking on 'Contribution Guidelines' now follows the link.