### PR TITLE
fix #656

### DIFF
--- a/Microsoft.DotNet.Interactive.Rendering.Tests/PlainTextFormatterTests.cs
+++ b/Microsoft.DotNet.Interactive.Rendering.Tests/PlainTextFormatterTests.cs
@@ -245,6 +245,18 @@ namespace Microsoft.DotNet.Interactive.Rendering.Tests
             }
 
             [Fact]
+            public void Tuple_values_are_formatted()
+            {
+                var tuple = Tuple.Create(123, "Hello", Enumerable.Range(1, 3));
+
+                var formatter = PlainTextFormatter.Create(tuple.GetType());
+
+                var formatted = tuple.ToDisplayString(formatter);
+
+                formatted.Should().Be("( 123, Hello, [ 1, 2, 3 ] )");
+            }
+            
+            [Fact]
             public void ValueTuple_values_are_formatted()
             {
                 var tuple = (123, "Hello", Enumerable.Range(1, 3));

--- a/Microsoft.DotNet.Interactive.Rendering/Formatter{T}.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/Formatter{T}.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 
 namespace Microsoft.DotNet.Interactive.Rendering
 {
@@ -15,6 +14,7 @@ namespace Microsoft.DotNet.Interactive.Rendering
     {
         internal static readonly bool TypeIsAnonymous = typeof(T).IsAnonymous();
         internal static readonly bool TypeIsException = typeof(Exception).IsAssignableFrom(typeof(T));
+        internal static readonly bool TypeIsTuple = typeof(T).IsTuple();
         internal static readonly bool TypeIsValueTuple = typeof(T).IsValueTuple();
 
         private static int? _listExpansionLimit;

--- a/Microsoft.DotNet.Interactive.Rendering/PlainTextFormatter.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/PlainTextFormatter.cs
@@ -37,7 +37,8 @@ namespace Microsoft.DotNet.Interactive.Rendering
         {
             var accessors = forMembers.GetMemberAccessors<T>();
 
-            if (Formatter<T>.TypeIsValueTuple)
+            if (Formatter<T>.TypeIsValueTuple || 
+                Formatter<T>.TypeIsTuple)
             {
                 return FormatValueTuple;
             }

--- a/Microsoft.DotNet.Interactive.Rendering/TypeExtensions.cs
+++ b/Microsoft.DotNet.Interactive.Rendering/TypeExtensions.cs
@@ -125,5 +125,15 @@ namespace Microsoft.DotNet.Interactive.Rendering
 
             return type.ToString().StartsWith("System.ValueTuple`");
         }
+        
+        public static bool IsTuple(this Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            return type.ToString().StartsWith("System.Tuple`");
+        }
     }
 }


### PR DESCRIPTION
This fixes the default plain text formatter output for `System.Tuple` variants.