### PR TITLE
Remove unnecessary Console.WriteLine

### DIFF
--- a/Microsoft.DotNet.Interactive/NativeAssemblyLoadHelper.cs
+++ b/Microsoft.DotNet.Interactive/NativeAssemblyLoadHelper.cs
@@ -200,7 +200,6 @@ namespace Microsoft.DotNet.Interactive
                 {
                     ptr = NativeLibrary.Load(dll);
                     Logger.Log.Info("NativeLibrary.Load({dll})", args.LoadedAssembly.Location);
-                    Console.WriteLine($"NativeLibrary.Load({dll})");
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
This is causing unnecessary output in the user's notebook.

@jonsequitur @KevinRansom 