### PR TITLE
F# completion

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,8 @@
 
   <!-- Consolidate FSharp package versions -->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19551.5" />
-    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19551.5" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0-beta.19572.3" />
+    <PackageReference Update="FSharp.Compiler.Private.Scripting" Version="11.0.0-beta.19572.3" />
     <PackageReference Update="FSharp.Compiler.Service" Version="31.0.0" />
   </ItemGroup>
 

--- a/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
+++ b/Microsoft.DotNet.Interactive.FSharp/FSharpKernel.fs
@@ -5,7 +5,6 @@ namespace Microsoft.DotNet.Interactive.FSharp
 
 open System
 open System.Collections.Generic
-open System.IO
 open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.Interactive.Shell
@@ -29,11 +28,11 @@ type FSharpKernel() =
     let messageMap = Dictionary<string, string>()
 
     let parseReference text =
-        let reference, binLogging = FSharpDependencyManager.parsePackageReference [text]
-        (reference |> List.tryHead), binLogging
+        let reference, binLogPath = FSharpDependencyManager.parsePackageReference [text]
+        (reference |> List.tryHead), binLogPath
 
-    let packageInstallingMessages (refSpec:PackageReference option * bool) =
-        let ref, binLogging = refSpec
+    let packageInstallingMessages (refSpec: PackageReference option * string option option) =
+        let ref, binLogPath = refSpec
         let versionText =
             match ref with
             | Some ref when ref.Version <> "*" -> ", version " + ref.Version
@@ -42,15 +41,15 @@ type FSharpKernel() =
         let installingMessage ref = "Installing package " + ref.Include + versionText + "."
         let loggingMessage = "Binary Logging enabled"
         [|
-            match ref, binLogging with
-            | Some reference, true ->
+            match ref, binLogPath with
+            | Some reference, Some _ ->
                 yield installingMessage reference
                 yield loggingMessage
-            | Some reference, false ->
+            | Some reference, None ->
                 yield installingMessage reference
-            | None, true ->
+            | None, Some _ ->
                 yield loggingMessage
-            | None, false ->
+            | None, None ->
                 ()
         |]
 

--- a/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
+++ b/Microsoft.DotNet.Interactive.FSharp/Microsoft.DotNet.Interactive.FSharp.fsproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Private.Scripting" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -845,17 +845,12 @@ json
 
         [Theory]
         [InlineData(Language.CSharp)]
-        //        [InlineData(Language.FSharp)]                 // Todo: need to generate CompletionRequestReceived event ... perhaps
+        [InlineData(Language.FSharp)]
         public async Task it_returns_completion_list_for_types(Language language)
         {
             var kernel = CreateKernel(language);
 
-            var source = language switch
-            {
-                Language.FSharp => @"System.Console.",
-
-                Language.CSharp => @"System.Console."
-            };
+            var source = "System.Console."; // same code is valid regarless of the language
 
             await kernel.SendAsync(new RequestCompletion(source, 15));
 
@@ -873,7 +868,7 @@ json
 
         [Theory]
         [InlineData(Language.CSharp)]
-        //[InlineData(Language.FSharp)]             //Todo: completion for F#
+        [InlineData(Language.FSharp)]
         public async Task it_returns_completion_list_for_previously_declared_variables(Language language)
         {
             var kernel = CreateKernel(language);

--- a/Microsoft.DotNet.Interactive.Tests/UtilityTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/UtilityTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Interactive.Utility;
+using Xunit;
+
+namespace Microsoft.DotNet.Interactive.Tests
+{
+    public class UtilityTests
+    {
+        [Fact]
+        public void replacement_position_can_be_found_at_the_end_of_a_string()
+        {
+            var code = "System.Linq.Enumerable.";
+            // finding this                   ^
+            var pos = SourceUtilities.ComputeReplacementStartPosition(code, code.Length);
+            Assert.Equal(code.Length, pos);
+        }
+
+        [Fact]
+        public void replacement_position_can_be_found_not_at_the_end_of_a_string()
+        {
+            var code = "System.Linq.Enumerable.Ran";
+            // finding this                   ^
+            var lastDotPos = code.LastIndexOf('.') + 1;
+            var pos = SourceUtilities.ComputeReplacementStartPosition(code, lastDotPos);
+            Assert.Equal(lastDotPos, pos);
+        }
+
+        [Fact]
+        public void replacement_position_can_be_found_at_the_end_of_a_multiline_string()
+        {
+            var code = @"
+using System.Linq;
+Enumerable.
+//        ^ finding this";
+            var lastDotPos = code.LastIndexOf('.') + 1;
+            var pos = SourceUtilities.ComputeReplacementStartPosition(code, lastDotPos);
+            Assert.Equal(lastDotPos, pos);
+        }
+
+        [Fact]
+        public void replacement_position_can_be_found_not_at_the_end_of_a_multiline_string()
+        {
+            var code = @"
+using System.Linq;
+Enumerable.Ran
+//        ^ finding this";
+            var lastDotPos = code.LastIndexOf('.') + 1;
+            var pos = SourceUtilities.ComputeReplacementStartPosition(code, lastDotPos);
+            Assert.Equal(lastDotPos, pos);
+        }
+    }
+}

--- a/Microsoft.DotNet.Interactive/Utility/SourceUtilities.cs
+++ b/Microsoft.DotNet.Interactive/Utility/SourceUtilities.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Interactive.Utility
+{
+    public static class SourceUtilities
+    {
+        private static readonly Regex _lastToken = new Regex(@"(?<lastToken>\S+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Given the specified code and cursor position, finds the location where replacement text will begin
+        /// insertion, usually the location of the last dot ('.').
+        /// </summary>
+        public static int ComputeReplacementStartPosition(string code, int cursorPosition)
+        {
+            var pos = cursorPosition;
+
+            if (pos > 0)
+            {
+                var codeToCursor = code.Substring(0, pos);
+                var match = _lastToken.Match(codeToCursor);
+                if (match.Success)
+                {
+                    var token = match.Groups["lastToken"];
+                    if (token.Success)
+                    {
+                        var lastDotPosition = token.Value.LastIndexOf(".", StringComparison.InvariantCultureIgnoreCase);
+                        if (lastDotPosition >= 0)
+                        {
+                            pos = token.Index + lastDotPosition + 1;
+                        }
+                        else
+                        {
+                            pos = token.Index;
+                        }
+                    }
+                }
+            }
+
+            return pos;
+        }
+    }
+}


### PR DESCRIPTION
Implement simple completion for F# kernel submissions.

This simply massages the F# completion results into something the kernel can use.  There was, however, an interesting issue I found where the calculation of the replacement span (essentially the last `'.'`) only took into consideration the first line of code.  This was due to the flag `RegexOptions.Multiline` being used which doesn't behave like we want.  The .NET `Regex` class treats the special regex characters `'^'` and `'$'` as the absolute beginning and end of the input string, e.g., `input[0]` and `input[input.Length - 1]`, but specifying the `RegexOptions.Multiline` flag makes the regex engine split on newlines and evaluate `'^'` and `'$'` for each line in the submission and then the match expression completed after evaluating the first line.  The result of this was that committing a completion item in Jupyter would end up trimming the entire code submission from the last `'.'` of the first line all the way to the end, where the correct behavior is to only do the replacement on the appropriate line.  Since this caused so much trouble for me I moved the function and made it public so it could be properly tested.

![image](https://user-images.githubusercontent.com/926281/69582762-20e6f100-0f8e-11ea-842d-b366dcbac5d5.png)
