### PR TITLE
Fix Issue #624 - #r nuget selects oldest package when version is not…

### DIFF
--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -1556,7 +1556,7 @@ using Microsoft.ML.AutoML;
         }
 
         [Fact]
-        public async Task issue_637()
+        public async Task Pound_r_nuget_with_System_Text_Json_should_succeed()
         {
             var kernel = CreateKernel(Language.CSharp);
 
@@ -1564,7 +1564,7 @@ using Microsoft.ML.AutoML;
 
             await kernel.SubmitCodeAsync(@"
 #r ""nuget:System.Text.Json""
-//using System.Text.Json;
+using System.Text.Json;
 ");
             // It should work, no errors and the requested package should be added
             events.Should()
@@ -1574,11 +1574,10 @@ using Microsoft.ML.AutoML;
             events.OfType<PackageAdded>()
                   .Should()
                   .ContainSingle(e => ((PackageAdded)e).PackageReference.PackageName == "Microsoft.NETCore.App.Ref");
-
         }
 
         [Fact]
-        public async Task issue_624()
+        public async Task Pound_r_nuget_with_no_version_should_not_get_the_oldest_package_version()
         {
             // #r "nuget: with no version specified should get the newest version of the package not the oldest:
             // For test purposes we evaluate the retrieved package is not the oldest version, since the newest may change over time.

--- a/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
+++ b/Microsoft.DotNet.Interactive.Tests/LanguageKernelTests.cs
@@ -1576,5 +1576,27 @@ using Microsoft.ML.AutoML;
                   .ContainSingle(e => ((PackageAdded)e).PackageReference.PackageName == "Microsoft.NETCore.App.Ref");
 
         }
+
+        [Fact]
+        public async Task issue_624()
+        {
+            // #r "nuget: with no version specified should get the newest version of the package not the oldest:
+            // For test purposes we evaluate the retrieved package is not the oldest version, since the newest may change over time.
+            var kernel = CreateKernel(Language.CSharp);
+
+            var events = kernel.KernelEvents.ToSubscribedList();
+
+            await kernel.SubmitCodeAsync(@"
+#r ""nuget:Microsoft.DotNet.PlatformAbstractions""
+");
+            // It should work, no errors and the latest requested package should be added
+            events.Should()
+                  .NotContainErrors();
+
+            events.OfType<PackageAdded>()
+                  .Should()
+                  .ContainSingle(e => ((PackageAdded)e).PackageReference.PackageName == "Microsoft.DotNet.PlatformAbstractions" && ((PackageAdded)e).PackageReference.PackageVersion != "1.0.3");
+        }
+
     }
 }

--- a/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
+++ b/Microsoft.DotNet.Interactive/PackageRestoreContext.cs
@@ -208,6 +208,11 @@ namespace s
 
             string PackageReferences()
             {
+                string GetReferenceVersion(PackageReference reference)
+                {
+                    return string.IsNullOrEmpty(reference.PackageVersion) ? "*" : reference.PackageVersion;
+                }
+
                 var sb = new StringBuilder();
 
                 sb.Append("  <ItemGroup>\n");
@@ -216,7 +221,7 @@ namespace s
                     .Values
                     .Where(reference => !string.IsNullOrEmpty(reference.PackageName))
                     .ToList()
-                    .ForEach(reference => sb.Append($"    <PackageReference Include=\"{reference.PackageName}\" Version=\"{reference.PackageVersion}\"/>\n"));
+                    .ForEach(reference => sb.Append($"    <PackageReference Include=\"{reference.PackageName}\" Version=\"{GetReferenceVersion(reference)}\"/>\n"));
 
                 sb.Append("  </ItemGroup>\n");
 


### PR DESCRIPTION
Fixes #624 - #r loads the oldest NuGet from the feed


By default when version is not specified nuget selects the oldest value in the feed.  This behaviour is not appropriate in a scripting environment when a developer is more likely to want the latest and greatest version.

This change uses "*"    select oldest stable version for the version value, when no version is specified.

