### PR TITLE
Change `interactive` to `try`

### DIFF
--- a/NotebooksLocalExperience.md
+++ b/NotebooksLocalExperience.md
@@ -14,16 +14,16 @@ First, make sure you have the following installed:
   python3        ~\jupyter\kernels\python3
 ```
 
-- Next, in an ordinary console, install the `dotnet interactive` global tool:
+- Next, in an ordinary console, install the `dotnet try` global tool:
 
 ```console
-> dotnet tool install -g dotnet-interactive
+> dotnet tool install -g dotnet-try
 ```
 
 - Install the .NET kernel by running the following within your Anaconda Prompt:
 
 ```console
-> dotnet interactive jupyter install
+> dotnet try jupyter install
 [InstallKernelSpec] Installed kernelspec .net-csharp in ~\jupyter\kernels\.net-csharp
 .NET kernel installation succeeded
 


### PR DESCRIPTION
I believe `interactive` has been updated to `try`:

```
PS C:\Users\nsg\AppData\Roaming\NuGet> dotnet tool install -g dotnet-interactive
error NU1101: Unable to find package dotnet-interactive. No packages exist with this id in source(s): C:\Program Files\dotnet\sdk\NuGetFallbackFolder, Microsoft Visual Studio Offline Packages, nuget.org
The tool package could not be restored.
Tool 'dotnet-interactive' failed to install. This failure may have been caused by:

* You are attempting to install a preview release and did not use the --version option to specify the version.
* A package by this name was found, but it was not a .NET Core tool.
* The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
* You mistyped the name of the tool.

For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool
```
then...
```
PS C:\Users\nsg\AppData\Roaming\NuGet> dotnet tool install -g dotnet-try
You can invoke the tool using the following command: dotnet-try
Tool 'dotnet-try' (version '1.0.19553.4') was successfully installed.
PS C:\Users\nsg\AppData\Roaming\NuGet> dotnet-try
```