### PR TITLE
Fix broken links and mismatch of link texts

### DIFF
--- a/docs/GettingStarted/PassingArgs.md
+++ b/docs/GettingStarted/PassingArgs.md
@@ -20,4 +20,4 @@ Instead of the familiar `Main(string[] args)` entry point, this program's entry 
 
 _Congratulations! You've finished the `dotnet try` step-by-step tutorial._
 
-**NEXT: [Using Read-only snippets &raquo;](./ReadOnlySnippets.md)**
+**NEXT: [Using Read-only Snippets &raquo;](./ReadOnlySnippets.md)**

--- a/docs/GettingStarted/ReadOnlySnippets.md
+++ b/docs/GettingStarted/ReadOnlySnippets.md
@@ -2,12 +2,12 @@
 
 - [Quick Start](./QuickStart.md)
 - [Create a New Project](./NewProject.md)
-- [Define Regions](./Regions.md)
+- [Show snippets using regions](./Regions.md)
 - [Create Sessions](./Sessions.md)
 - [Verify your Project](./Verify.md)
 - [Passing Arguments](./PassingArgs.md)
 - **Using Read-only Snippets**
-- [Glossary](./Glossary.md)
+- [Reference](./Reference.md)
 
 
 ```cs  --editable false --region usings --destination-file ./Snippets/Program.cs --project ./Snippets/Snippets.csproj
@@ -64,7 +64,7 @@ namespace Snippets
             #endregion
 
             Console.WriteLine("this is from hidden include");
-        }        
+        }
     }
 
 ```

--- a/docs/GettingStarted/Reference.md
+++ b/docs/GettingStarted/Reference.md
@@ -1,4 +1,4 @@
-# Glossary
+# Reference
 
 - [Quick Start](./QuickStart.md)
 - [Create a New Project](./NewProject.md)
@@ -7,7 +7,7 @@
 - [Verify your Project](./Verify.md)
 - [Passing Arguments](./PassingArgs.md)
 - [Using Read-only Snippets](./ReadOnlySnippets.md)
-- **Glossary**
+- **Reference**
 
 ### dotnet try
 

--- a/docs/GettingStarted/Regions.md
+++ b/docs/GettingStarted/Regions.md
@@ -62,4 +62,4 @@ This is done using the `--region` option, which targets a [C# code region](https
     Console.WriteLine("Hello World!");
     ```
 
-**NEXT: [Define Sessions &raquo;](./Sessions.md)**
+**NEXT: [Create Sessions &raquo;](./Sessions.md)**

--- a/docs/GettingStarted/Sessions.md
+++ b/docs/GettingStarted/Sessions.md
@@ -2,12 +2,12 @@
 
 - [Quick Start](./QuickStart.md)
 - [Create a New Project](./NewProject.md)
-- [Define Regions](./Regions.md)
+- [Show snippets using regions](./Regions.md)
 - **Create Sessions**
 - [Verify your Project](./Verify.md)
 - [Passing Arguments](./PassingArgs.md)
 - [Using Read-only Snippets](./ReadOnlySnippets.md)
-- [Glossary](./Glossary.md)
+- [Reference](./Reference.md)
 
 Let's make this a little more interesting. Your project probably has more than one snippet you want people to be able to run. Sessions allow you to run these code snippets independently of one another.
 

--- a/docs/GettingStarted/Verify.md
+++ b/docs/GettingStarted/Verify.md
@@ -23,4 +23,4 @@ Try making other changes to the code fence options. Mistype an option name, spec
 
 When `dotnet try verify` detects errors, it will return a non-zero exit code. When everything looks good, it returns `0`. You can use this in your continuous integration scripts to prevent code changes from breaking your documentation.
 
-**NEXT: [Passing Arguments to your Project &raquo;](./PassingArgs.md)**
+**NEXT: [Passing Arguments &raquo;](./PassingArgs.md)**


### PR DESCRIPTION
Links to the reference page were broken. Some page link texts were mismatching to others, so I corrected them according to most others.