### PR TITLE
add support for annotated console code blocks

### DIFF
--- a/MLS.Agent/Controllers/DocumentationController.cs
+++ b/MLS.Agent/Controllers/DocumentationController.cs
@@ -110,11 +110,12 @@ namespace MLS.Agent.Controllers
 
             foreach (var session in sessions)
             {
-                sb.AppendLine($@"<button class=""run"" data-trydotnet-mode=""run"" data-trydotnet-session-id=""{session.Key}"" data-trydotnet-run-args=""{session.First().Annotations.RunArgs.HtmlAttributeEncode()}"">{session.Key}{SvgResources.RunButtonSvg}</button>");
+                sb.AppendLine(
+                    $@"<button class=""run"" data-trydotnet-mode=""run"" data-trydotnet-session-id=""{session.Key}"" data-trydotnet-run-args=""{session.Select(s => s.Annotations).OfType<CodeBlockAnnotations>().First().RunArgs.HtmlAttributeEncode()}"">{session.Key}{SvgResources.RunButtonSvg}</button>");
 
                 sb.AppendLine(enablePreviewFeatures
-                    ? $@"<div class=""output-panel"" data-trydotnet-mode=""runResult"" data-trydotnet-output-type=""terminal"" data-trydotnet-session-id=""{session.Key}""></div>"
-                    : $@"<div class=""output-panel"" data-trydotnet-mode=""runResult"" data-trydotnet-session-id=""{session.Key}""></div>");
+                                  ? $@"<div class=""output-panel"" data-trydotnet-mode=""runResult"" data-trydotnet-output-type=""terminal"" data-trydotnet-session-id=""{session.Key}""></div>"
+                                  : $@"<div class=""output-panel"" data-trydotnet-mode=""runResult"" data-trydotnet-session-id=""{session.Key}""></div>");
             }
 
             return new HtmlString(sb.ToString());

--- a/MLS.Agent/Markdown/AnnotatedCodeBlockExtensions.cs
+++ b/MLS.Agent/Markdown/AnnotatedCodeBlockExtensions.cs
@@ -1,10 +1,11 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.DotNet.Try.Markdown;
 using Microsoft.DotNet.Try.Protocol;
 using MLS.Agent.Tools;
-using WorkspaceServer;
+using Buffer = Microsoft.DotNet.Try.Protocol.Buffer;
 
 namespace MLS.Agent.Markdown
 {
@@ -19,7 +20,7 @@ namespace MLS.Agent.Markdown
             {
                 var file = localOptions.SourceFile ?? localOptions.DestinationFile;
                 var absolutePath = directoryAccessor.GetFullyQualifiedPath(file).FullName;
-                var bufferId = new BufferId(absolutePath, block.Annotations.Region);
+                var bufferId = new BufferId(absolutePath, localOptions.Region);
                 return new Buffer(bufferId, block.SourceCode);
             }
 
@@ -28,20 +29,25 @@ namespace MLS.Agent.Markdown
 
         public static string ProjectOrPackageName(this AnnotatedCodeBlock block)
         {
-            return
-                (block.Annotations as LocalCodeBlockAnnotations)?.Project?.FullName ??
-                block.Annotations?.Package;
+            if (block.Annotations is LocalCodeBlockAnnotations a1 && 
+                a1.Project?.FullName is { } fullName)
+            {
+                return fullName;
+            }
+
+            if (block.Annotations is CodeBlockAnnotations a2)
+            {
+                return a2.Package;
+            }
+
+            return null;
         }
 
         public static string PackageName(this AnnotatedCodeBlock block)
         {
-            return block.Annotations?.Package;
+            return (block.Annotations as CodeBlockAnnotations)?.Package;
         }
-        
-        public static string Language(this AnnotatedCodeBlock block)
-        {
-            return
-                block.Annotations?.NormalizedLanguage;
-        }
+
+        public static string Language(this AnnotatedCodeBlock block) => block.Annotations?.NormalizedLanguage;
     }
 }

--- a/MLS.Agent/Markdown/LocalCodeFenceAnnotationsParser.cs
+++ b/MLS.Agent/Markdown/LocalCodeFenceAnnotationsParser.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.CommandLine;
-using System.CommandLine.Binding;
 using System.IO;
 using System.Linq;
 using Markdig;
@@ -59,15 +58,12 @@ namespace MLS.Agent.Markdown
             return result;
         }
 
-        protected override ModelBinder CreateModelBinder()
-        {
-            return new ModelBinder(typeof(LocalCodeBlockAnnotations));
-        }
+        public override Type CodeBlockAnnotationsType => typeof(LocalCodeBlockAnnotations);
 
         private static void AddSourceFileOption(Command command)
         {
             var sourceFileArg = new Argument<RelativeFilePath>(
-                parse: (result) =>
+                parse: result =>
                 {
                     var filename = result.Tokens.Select(t => t.Value).SingleOrDefault();
 

--- a/MLS.Agent/Markdown/MarkdownProject.cs
+++ b/MLS.Agent/Markdown/MarkdownProject.cs
@@ -5,10 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reactive.Disposables;
-using System.Threading.Tasks;
 using Markdig;
-using Markdig.Extensions.Mathematics;
 using Microsoft.DotNet.Try.Markdown;
 using MLS.Agent.Tools;
 using Recipes;
@@ -62,11 +59,6 @@ namespace MLS.Agent.Markdown
             public IDirectoryAccessor GetDirectoryAccessorForRelativePath(RelativeDirectoryPath relativePath)
             {
                 return this;
-            }
-
-            public Task<IDisposable> TryLockAsync()
-            {
-                return Task.FromResult(Disposable.Empty);
             }
 
             public void WriteAllText(RelativeFilePath path, string text)

--- a/Microsoft.DotNet.Try.Markdown.Tests/AnnotatedCodeBlockTests.cs
+++ b/Microsoft.DotNet.Try.Markdown.Tests/AnnotatedCodeBlockTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using FluentAssertions;
-using Microsoft.DotNet.Try.Markdown;
 using Xunit;
 
 namespace Microsoft.DotNet.Try.Markdown.Tests
@@ -13,7 +12,7 @@ namespace Microsoft.DotNet.Try.Markdown.Tests
         [Fact]
         public void It_requires_options_to_initialize()
         {
-            var block = new AnnotatedCodeBlock(); 
+            var block = new AnnotatedCodeBlock();
 
             block.Invoking(b => b.InitializeAsync().Wait())
                  .Should()

--- a/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlockRenderer.cs
+++ b/Microsoft.DotNet.Try.Markdown/AnnotatedCodeBlockRenderer.cs
@@ -19,17 +19,17 @@ namespace Microsoft.DotNet.Try.Markdown
             HtmlRenderer renderer,
             CodeBlock codeBlock)
         {
-            if (codeBlock is AnnotatedCodeBlock codeLinkBlock)
+            if (codeBlock is AnnotatedCodeBlock block)
             {
-                codeLinkBlock.EnsureInitialized();
+                block.EnsureInitialized();
 
-                if (codeLinkBlock.Diagnostics.Any())
+                if (block.Diagnostics.Any())
                 {
 
                     renderer.WriteLine(@"<div class=""notification is-danger"">");
                     renderer.WriteLine(SvgResources.ErrorSvg);
 
-                    foreach (var diagnostic in codeLinkBlock.Diagnostics)
+                    foreach (var diagnostic in block.Diagnostics)
                     {
                         renderer.WriteEscape("\t" + diagnostic);
                         renderer.WriteLine();
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Try.Markdown
                 }
                 else
                 {
-                    codeLinkBlock.RenderTo(
+                    block.RenderTo(
                         renderer,
                         InlineControls,
                         EnablePreviewFeatures);

--- a/Microsoft.DotNet.Try.Markdown/CodeBlockAnnotations.cs
+++ b/Microsoft.DotNet.Try.Markdown/CodeBlockAnnotations.cs
@@ -6,12 +6,11 @@ using System.CommandLine.Parsing;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Xml;
 using MLS.Agent.Tools;
 
 namespace Microsoft.DotNet.Try.Markdown
 {
-    public class CodeBlockAnnotations
+    public class CodeBlockAnnotations : CodeFenceAnnotations
     {
         protected static int _sessionIndex;
 
@@ -24,14 +23,14 @@ namespace Microsoft.DotNet.Try.Markdown
             bool hidden = false,
             string runArgs = null,
             ParseResult parseResult = null,
-            string packageVersion = null)
+            string packageVersion = null) 
+            : base(parseResult, session)
         {
             DestinationFile = destinationFile;
             Package = package;
             Region = region;
             Session = session;
             RunArgs = runArgs;
-            ParseResult = parseResult;
             PackageVersion = packageVersion;
             Editable = !hidden && editable;
             Hidden = hidden;
@@ -40,9 +39,7 @@ namespace Microsoft.DotNet.Try.Markdown
             {
                 Session = $"Run{++_sessionIndex}";
             }
-
-            NormalizedLanguage = parseResult?.CommandResult.Command.Name;
-            Language = parseResult?.Tokens.First().Value;
+         
             RunArgs = runArgs ?? Untokenize(parseResult);
         }
 
@@ -50,13 +47,9 @@ namespace Microsoft.DotNet.Try.Markdown
         public RelativeFilePath DestinationFile { get; }
         public string Region { get; }
         public string RunArgs { get; }
-        public ParseResult ParseResult { get; }
         public string PackageVersion { get; }
-        public string Session { get; }
         public bool Editable { get; }
         public bool Hidden { get; }
-        public string Language { get; }
-        public string NormalizedLanguage { get; }
 
         public virtual Task<CodeBlockContentFetchResult> TryGetExternalContent() => 
             Task.FromResult(CodeBlockContentFetchResult.None);

--- a/Microsoft.DotNet.Try.Markdown/CodeFenceAnnotations.cs
+++ b/Microsoft.DotNet.Try.Markdown/CodeFenceAnnotations.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.CommandLine.Parsing;
+using System.Linq;
+
+namespace Microsoft.DotNet.Try.Markdown
+{
+    public abstract class CodeFenceAnnotations
+    {
+        protected CodeFenceAnnotations(
+            ParseResult parseResult, 
+            string session = null)
+        {
+            ParseResult = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
+            Session = session;
+
+            NormalizedLanguage = parseResult?.CommandResult.Command.Name;
+            Language = parseResult?.Tokens.First().Value;
+        }
+
+        
+        public ParseResult ParseResult { get; }
+        
+        public string Session { get; protected set; }
+        
+        public string Language { get; }
+        
+        public string NormalizedLanguage { get; }
+    }
+}

--- a/Microsoft.DotNet.Try.Markdown/CodeFenceOptionsParseResult.cs
+++ b/Microsoft.DotNet.Try.Markdown/CodeFenceOptionsParseResult.cs
@@ -13,8 +13,10 @@ namespace Microsoft.DotNet.Try.Markdown
 
         public static CodeFenceOptionsParseResult Failed(IList<string> errorMessages) => new FailedCodeFenceOptionParseResult(errorMessages);
 
+        public static CodeFenceOptionsParseResult Failed(string errorMessage) => new FailedCodeFenceOptionParseResult(new[] { errorMessage });
+
         public static CodeFenceOptionsParseResult None { get; } = new NoCodeFenceOptions();
 
-        public static CodeFenceOptionsParseResult Succeeded(CodeBlockAnnotations annotations) => new SuccessfulCodeFenceOptionParseResult(annotations);
+        public static CodeFenceOptionsParseResult Succeeded(CodeFenceAnnotations annotations) => new SuccessfulCodeFenceOptionParseResult(annotations);
     }
 }

--- a/Microsoft.DotNet.Try.Markdown/MarkdownParserContextExtensions.cs
+++ b/Microsoft.DotNet.Try.Markdown/MarkdownParserContextExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Markdig;
-using Markdig.Helpers;
 
 namespace Microsoft.DotNet.Try.Markdown
 {

--- a/Microsoft.DotNet.Try.Markdown/MarkdownPipelineBuilderExtensions.cs
+++ b/Microsoft.DotNet.Try.Markdown/MarkdownPipelineBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Try.Markdown
     public static class MarkdownPipelineBuilderExtensions
     {
         public static MarkdownPipelineBuilder UseCodeBlockAnnotations(
-            this MarkdownPipelineBuilder pipeline, 
+            this MarkdownPipelineBuilder pipeline,
             CodeFenceAnnotationsParser annotationsParser = null,
             bool inlineControls = true)
         {
@@ -16,7 +16,10 @@ namespace Microsoft.DotNet.Try.Markdown
 
             if (!extensions.Contains<CodeBlockAnnotationExtension>())
             {
-                extensions.Add(new CodeBlockAnnotationExtension(annotationsParser) {InlineControls = inlineControls});
+                extensions.Add(new CodeBlockAnnotationExtension(annotationsParser)
+                {
+                    InlineControls = inlineControls
+                });
             }
 
             return pipeline;

--- a/Microsoft.DotNet.Try.Markdown/NormalizeBlockAnnotationExtension.cs
+++ b/Microsoft.DotNet.Try.Markdown/NormalizeBlockAnnotationExtension.cs
@@ -28,9 +28,10 @@ namespace Microsoft.DotNet.Try.Markdown
                 NormalizeRenderer renderer,
                 CodeBlock codeBlock)
             {
-                if (codeBlock is AnnotatedCodeBlock codeLinkBlock && codeLinkBlock.Annotations != null)
+                if (codeBlock is AnnotatedCodeBlock block && 
+                    block.Annotations is CodeBlockAnnotations annotations)
                 {
-                    codeLinkBlock.Arguments = $"{codeLinkBlock.Annotations.Language} {codeLinkBlock.Annotations.RunArgs}";
+                    block.Arguments = $"{block.Annotations.Language} {annotations.RunArgs}";
                 }
                 base.Write(renderer, codeBlock);
             }

--- a/Microsoft.DotNet.Try.Markdown/OutputBlockAnnotations.cs
+++ b/Microsoft.DotNet.Try.Markdown/OutputBlockAnnotations.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Parsing;
+
+namespace Microsoft.DotNet.Try.Markdown
+{
+    public class OutputBlockAnnotations : CodeFenceAnnotations
+    {
+        public OutputBlockAnnotations(
+            ParseResult parseResult = null,
+            string session = null)
+            : base(parseResult, session)
+        {
+        }
+    }
+}

--- a/Microsoft.DotNet.Try.Markdown/SuccessfulCodeFenceOptionParseResult.cs
+++ b/Microsoft.DotNet.Try.Markdown/SuccessfulCodeFenceOptionParseResult.cs
@@ -5,11 +5,11 @@ namespace Microsoft.DotNet.Try.Markdown
 {
     public sealed class SuccessfulCodeFenceOptionParseResult : CodeFenceOptionsParseResult
     {
-        public SuccessfulCodeFenceOptionParseResult(CodeBlockAnnotations annotations)
+        internal SuccessfulCodeFenceOptionParseResult(CodeFenceAnnotations annotations)
         {
             Annotations = annotations;
         }
 
-        public CodeBlockAnnotations Annotations { get; }
+        public CodeFenceAnnotations Annotations { get; internal set; }
     }
 }

--- a/Microsoft.DotNet.Try.ProjectTemplate.Tests/TutorialTemplateTests.cs
+++ b/Microsoft.DotNet.Try.ProjectTemplate.Tests/TutorialTemplateTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Try.ProjectTemplate.Tests
 {
     public class TutorialTemplateTests
     {
-        private string _pathToTemplateCsproj;
+        private readonly string _pathToTemplateCsproj;
 
         public TutorialTemplateTests()
         {


### PR DESCRIPTION
The goal here is to provide a way to show code blocks for output when a `dotnet-try`-able Markdown file is displayed in a non-interactive context, e.g. GitHub, but for those code blocks to be hidden when running the file interactively using `dotnet-try`.

Here's the static Markdown view:

![image](https://user-images.githubusercontent.com/547415/87483153-dcc16300-c5e7-11ea-900a-841d6f2c590c.png)

Here's the interactive view:

![image](https://user-images.githubusercontent.com/547415/87483238-198d5a00-c5e8-11ea-9ae6-5b624e9f82c0.png)

