### PR TITLE
enable post-build arcade steps to publish packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   - name: _BuildConfig
     value: Release
   - name: _PublishUsingPipelines
-    value: false
+    value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: BlazorTemplateVersion
@@ -33,10 +33,8 @@ stages:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
-      enablePublishBuildAssets: false
+      enablePublishBuildAssets: true
       enablePublishUsingPipelines: $(_PublishUsingPipelines)
-      enableTelemetry: true
-      helixRepo: dotnet/try
       jobs:
       - job: Windows_NT
         pool:
@@ -48,21 +46,27 @@ stages:
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
           - name: _SignType
             value: Real
+          - name: _DotNetPublishToBlobFeed
+            value: true
           - name: _BuildArgs
             value: /p:SignType=$(_SignType)
                    /p:DotNetSignType=$(_SignType)
                    /p:MicroBuild_SigningEnabled=true
                    /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
                    /p:TeamName=$(_TeamName)
+                   /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                   /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                   /p:DotNetPublishToBlobFeed=true
                    /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                   /p:PublishToSymbolServer=true
                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                   /p:PublishToSymbolServer=true
         # else
         - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           - name: _SignType
@@ -137,9 +141,7 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: false
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
-      enableTelemetry: true
-      helixRepo: dotnet/try
+      enablePublishUsingPipelines: false
       jobs:
       - job: Linux
         pool:
@@ -233,8 +235,6 @@ stages:
   # - template: /eng/common/templates/jobs/jobs.yml
   #   parameters:
   #     enableMicrobuild: true
-  #     enableTelemetry: true
-  #     helixRepo: dotnet/try
   #     jobs:
   #     - job: IntegrationTest
   #       dependsOn: Windows_NT
@@ -283,6 +283,17 @@ stages:
   #           searchFolder: '$(SystemWorkingDirectory)/testResults'
   #         continueOnError: true
   #         condition: always()
+
+#---------------------------------------------------------------------------------------------------------------------#
+#                                                    Post Build                                                       #
+#---------------------------------------------------------------------------------------------------------------------#
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng/common/templates/post-build/post-build.yml
+    parameters:
+      # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+      enableSymbolValidation: false
+      # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
+      enableSourceLinkValidation: false
 
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                  Package upload                                                     #

--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0build.ps1" -ci -restore -build -pack -binaryLog %*
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0build.ps1" -ci -restore -build -pack -publish -binaryLog %*

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,6 @@
+*bundle.js
+blazor.*.js
+editor.worker.js
+interop.js
+mono.js
+trydotnet.min.js

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,47 +1,49 @@
 <Project>
 
   <ItemGroup>
-    <FileSignInfo Include="Mono.Security.dll" CertificateName="None" />
-    <FileSignInfo Include="mscorlib.dll" CertificateName="None" />
-    <FileSignInfo Include="netstandard.dll" CertificateName="None" />
-    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Core.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Data.dll" CertificateName="None" />
-    <FileSignInfo Include="System.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Drawing.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Drawing.Common.dll" CertificateName="None" />
-    <FileSignInfo Include="System.IO.Compression.dll" CertificateName="None" />
-    <FileSignInfo Include="System.IO.Compression.FileSystem.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Linq.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Net.Http.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Numerics.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Runtime.Serialization.dll" CertificateName="None" />
-    <FileSignInfo Include="System.ServiceModel.Internals.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Transactions.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Web.Services.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Xml.dll" CertificateName="None" />
-    <FileSignInfo Include="System.Xml.Linq.dll" CertificateName="None" />
+    <!-- mono binaries from blazor -->
+    <FileSignInfo Include="Mono.Security.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="mscorlib.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="netstandard.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Core.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Data.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Drawing.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Drawing.Common.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.IO.Compression.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.IO.Compression.FileSystem.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Linq.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Net.Http.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Numerics.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Runtime.Serialization.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.ServiceModel.Internals.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Transactions.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Web.Services.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Xml.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="System.Xml.Linq.dll" CertificateName="3PartySHA2" />
 
-    <FileSignInfo Include="AsyncIO.dll" CertificateName="None" />
-    <FileSignInfo Include="Buildalyzer.dll" CertificateName="None" />
-    <FileSignInfo Include="Buildalyzer.Logger.dll" CertificateName="None" />
-    <FileSignInfo Include="MsBuildPipeLogger.Logger.dll" CertificateName="None" />
-    <FileSignInfo Include="Buildalyzer.Workspaces.dll" CertificateName="None" />
-    <FileSignInfo Include="Clockwise.dll" CertificateName="None" />
-    <FileSignInfo Include="HtmlAgilityPack.dll" CertificateName="None" />
-    <FileSignInfo Include="Markdig.dll" CertificateName="None" />
-    <FileSignInfo Include="MessagePack.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="None" />
-    <FileSignInfo Include="Mono.Cecil.dll" CertificateName="None" />
-    <FileSignInfo Include="StructuredLogger.dll" CertificateName="None" />
-    <FileSignInfo Include="MsBuildPipeLogger.Server.dll" CertificateName="None" />
-    <FileSignInfo Include="NetMQ.dll" CertificateName="None" />
-    <FileSignInfo Include="Octokit.dll" CertificateName="None" />
-    <FileSignInfo Include="Serilog.dll" CertificateName="None" />
-    <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="None" />
-    <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="None" />
+    <!-- other 3rd party assemblies -->
+    <FileSignInfo Include="AsyncIO.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Buildalyzer.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Buildalyzer.Logger.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MsBuildPipeLogger.Logger.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Buildalyzer.Workspaces.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Clockwise.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="HtmlAgilityPack.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Markdig.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MessagePack.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Cecil.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="StructuredLogger.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MsBuildPipeLogger.Server.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="NetMQ.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Octokit.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Sinks.RollingFileAlternate.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="XPlot.Plotly.dll" CertificateName="3PartySHA2" />
 
     <FileSignInfo Include="materialdesignicons-webfont.ttf" CertificateName="None" />
   </ItemGroup>


### PR DESCRIPTION
There's an effort to remove the `dotnet.myget.org` dependency and this PR makes it so that signed builds from this repo are published to the `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json` NuGet feed.

A future PR will remove `dotnet.myget.org` publishing and URLs from package restore sources, as well.

This branch passed a full internal build [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=844314&view=results).