### PR TITLE
Use non-deprecated Azure Pipelines Ubuntu pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ stages:
       jobs:
       - job: Linux
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-20.04
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -240,7 +240,7 @@ stages:
   #       dependsOn: Windows_NT
   #       condition: succeeded()
   #       pool:
-  #         vmImage: ubuntu-16.04
+  #         vmImage: ubuntu-20.04
   #       variables:
   #         - name: PACKAGESOURCE
   #           value: $(System.DefaultWorkingDirectory)/packages/Shipping


### PR DESCRIPTION
ubuntu-16.04 was removed, bumping to 20.04