### PR TITLE
make (local) arcade build happy

### DIFF
--- a/Microsoft.DotNet.Interactive.Telemetry.Tests/Microsoft.DotNet.Interactive.Telemetry.Tests.csproj
+++ b/Microsoft.DotNet.Interactive.Telemetry.Tests/Microsoft.DotNet.Interactive.Telemetry.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Assent" Version="1.3.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Pocket.Disposable" Version="1.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NuGet.config
+++ b/NuGet.config
@@ -8,6 +8,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="MachineLearning" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json" />

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <!-- Appends the extension `.renamed` to the dotnet-* packages to force the glob `*.nupkg` to not pick it up. -->
-  <Target Name="RenameDotNetTryOutputPackage" BeforeTargets="PackageReleasePackages">
+  <Target Name="RenameDotNetTryOutputPackage" BeforeTargets="PackageReleasePackages" Condition="@(StableVersionPackages->Count()) &gt; 0">
     <Move SourceFiles="%(StableVersionPackages.FullPath)" DestinationFiles="%(StableVersionPackages.FullPath).renamed" />
   </Target>
 
   <!-- Removes the `.renamed` extension from the dotnet-* packages. -->
-  <Target Name="RestoreDotNetTryOutputPackage" AfterTargets="PackageReleasePackages">
+  <Target Name="RestoreDotNetTryOutputPackage" AfterTargets="PackageReleasePackages" Condition="@(StableVersionPackages->Count()) &gt; 0">
     <Move SourceFiles="%(StableVersionPackages.FullPath).renamed" DestinationFiles="%(StableVersionPackages.FullPath)" />
   </Target>
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -12,7 +12,7 @@ function TestUsingNPM([string] $testPath) {
 
 try {
     # invoke regular build/test script
-    . (Join-Path $PSScriptRoot "common\build.ps1") /p:Projects=$PSScriptRoot\..\dotnet-try.sln @args
+    . (Join-Path $PSScriptRoot "common\build.ps1") /p:Projects=$PSScriptRoot\..\TryDotNet.sln @args
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -36,7 +36,7 @@ function TestUsingNPM() {
 }
 
 # invoke regular build/test script
-. "$scriptroot/common/build.sh" /p:Projects=$scriptroot/../dotnet-try.sln $args
+. "$scriptroot/common/build.sh" /p:Projects=$scriptroot/../TryDotNet.sln $args
 
 # directly invoke npm tests
 if [[ "$run_tests" == "true" ]]; then

--- a/src/Microsoft.TryDotNet.IntegrationTests/CommandLine.cs
+++ b/src/Microsoft.TryDotNet.IntegrationTests/CommandLine.cs
@@ -14,7 +14,7 @@ public static class CommandLine
     public static Task<CommandLineResult> Execute(
         FileInfo exePath,
         string args,
-        DirectoryInfo workingDir = null,
+        DirectoryInfo? workingDir = null,
         TimeSpan? timeout = null) =>
         Execute(exePath.FullName,
             args,
@@ -25,7 +25,7 @@ public static class CommandLine
     public static async Task<CommandLineResult> Execute(
         string command,
         string args,
-        DirectoryInfo workingDir = null,
+        DirectoryInfo? workingDir = null,
         TimeSpan? timeout = null)
     {
         args ??= "";
@@ -106,9 +106,9 @@ public static class CommandLine
     public static Process StartProcess(
         string command,
         string args,
-        DirectoryInfo workingDir,
-        Action<string> output = null,
-        Action<string> error = null,
+        DirectoryInfo? workingDir,
+        Action<string>? output = null,
+        Action<string>? error = null,
         params (string key, string value)[] environmentVariables)
     {
         using (var operation = Log.OnEnterAndExit())
@@ -171,7 +171,7 @@ public static class CommandLine
         }
     }
 
-    public static string AppendArgs(this string initial, string append = null) =>
+    public static string AppendArgs(this string initial, string? append = null) =>
         string.IsNullOrWhiteSpace(append)
             ? initial
             : $"{initial} {append}";
@@ -179,7 +179,7 @@ public static class CommandLine
     private static ConfirmationLogger ConfirmOnExit(
         object command,
         string args,
-        [CallerMemberName] string operationName = null)
+        [CallerMemberName] string? operationName = null)
     {
         return new ConfirmationLogger(
             operationName: operationName,

--- a/src/Microsoft.TryDotNet.IntegrationTests/CommandLineInvocationException.cs
+++ b/src/Microsoft.TryDotNet.IntegrationTests/CommandLineInvocationException.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TryDotNet.IntegrationTests;
 
 public class CommandLineInvocationException : Exception
 {
-    public CommandLineInvocationException(CommandLineResult result, string message = null) : base(
+    public CommandLineInvocationException(CommandLineResult result, string? message = null) : base(
         $"{message}{Environment.NewLine}Exit code {result.ExitCode}: {string.Join("\n", result.Error)}".Trim())
     {
     }

--- a/src/Microsoft.TryDotNet.IntegrationTests/Microsoft.TryDotNet.IntegrationTests.csproj
+++ b/src/Microsoft.TryDotNet.IntegrationTests/Microsoft.TryDotNet.IntegrationTests.csproj
@@ -10,16 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Assent" Version="1.7.0" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.20.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.TryDotNet.SimulatorGenerator/MarkupTestFile.cs
+++ b/src/Microsoft.TryDotNet.SimulatorGenerator/MarkupTestFile.cs
@@ -289,9 +289,24 @@ namespace Microsoft.TryDotNet.Tests
             {
             }
 
-            public int Compare(Tuple<int, string> x, Tuple<int, string> y)
+            public int Compare(Tuple<int, string>? x, Tuple<int, string>? y)
             {
-                return x.Item1 - y.Item1;
+                if (x is null && y is null)
+                {
+                    return 0;
+                }
+                else if (x is null)
+                {
+                    return -1;
+                }
+                else if (y is null)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return x.Item1 - y.Item1;
+                }
             }
         }
     }

--- a/src/Microsoft.TryDotNet.Tests/Microsoft.TryDotNet.Tests.csproj
+++ b/src/Microsoft.TryDotNet.Tests/Microsoft.TryDotNet.Tests.csproj
@@ -9,14 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Assent" Version="1.7.0" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.TryDotNet.WasmRunner/Pages/Index.razor
+++ b/src/Microsoft.TryDotNet.WasmRunner/Pages/Index.razor
@@ -5,5 +5,3 @@
 <h1>Hello, world!</h1>
 
 Welcome to your new app.
-
-<SurveyPrompt Title="How is Blazor working for you?" />

--- a/src/Microsoft.TryDotNet/Microsoft.TryDotNet.csproj
+++ b/src/Microsoft.TryDotNet/Microsoft.TryDotNet.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);NU5100</NoWarn><!-- don't complain about assemblies not in the `lib/` subdirectory -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This involved not explicitly specifying unit test packages and adding more null annotations.

The `FluentAssertions` package version `6.5.1` doesn't yet exist on the internal package feeds, so this'll likely fail until then.  An internal request has been submitted to migrate that package.