### PR TITLE
Skip tests option

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,9 @@
+parameters:
+- name: SkipTests
+  displayName: Skip Tests
+  type: boolean
+  default: false
+
 # CI and PR triggers
 trigger:
 - main


### PR DESCRIPTION
This _should_ add a `Skip Tests` checkbox when we manually queue a build, but unfortunately there's no way to test it without pushing to `main`.

I'm basing this PR on the documentation found [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops&tabs=script) and as observed in a private internal repo.  Once this is in and working we can then work on plumbing the `$(SkipTests)` variable through.