### PR TITLE
fix: Update to override scheme from environmental variable if necessary

### DIFF
--- a/src/Microsoft.TryDotNet/ContentGenerator.cs
+++ b/src/Microsoft.TryDotNet/ContentGenerator.cs
@@ -11,7 +11,13 @@ public class ContentGenerator
     public static Task<string> GenerateEditorPageAsync(HttpRequest request)
     {
         var referer = request.Headers.Referer.FirstOrDefault();
-        var hostUri = new Uri(request.Scheme + "://" +  request.Host.Value, UriKind.Absolute);
+
+        // This allows us to specify when running in specific environments (i.e. containers) what scheme to use
+        var scheme = Environment.GetEnvironmentVariable("TRY_DOT_NET_REQUEST_SCHEME") 
+                    ?? request.Scheme 
+                    ?? "http";
+
+        var hostUri = new Uri($"{scheme}://{request.Host.Value}", UriKind.Absolute);
         var wasmRunnerUri = new Uri(hostUri, "/wasmrunner");
         var commansdUri = new Uri(hostUri, "/commands");
         var enableLogging = false;

--- a/src/Microsoft.TryDotNet/ContentGenerator.cs
+++ b/src/Microsoft.TryDotNet/ContentGenerator.cs
@@ -13,6 +13,9 @@ public class ContentGenerator
         var referer = request.Headers.Referer.FirstOrDefault();
 
         // This allows us to specify when running in specific environments (i.e. containers) what scheme to use
+        //   The enviromental variable is useful when running behind a reverse proxy that terminates SSL
+        //   request.Scheme should be used when running in a development environment or as a normal website.
+        //   "http" is the default if no other scheme is specified.
         var scheme = Environment.GetEnvironmentVariable("TRY_DOT_NET_REQUEST_SCHEME") 
                     ?? request.Scheme 
                     ?? "http";


### PR DESCRIPTION
This fix will allow you to specify as an environmental variable what scheme to use when returning data back to the caller.  

If it is null, it will default to request.Scheme.  If that is null as well, then we default to http.

#1115 