### PR TITLE
Remove swashbuckle.aspnetcore.swaggerui.6.5.0.nupkg

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />

--- a/src/Microsoft.TryDotNet/Microsoft.TryDotNet.csproj
+++ b/src/Microsoft.TryDotNet/Microsoft.TryDotNet.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Interactive.CSharpProject" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="System.Net.Http" />


### PR DESCRIPTION
Fix governance compliance detected in [swaggerui.6.5.0](https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-try/alert/9216377?typeId=4330681)