### PR TITLE
Update NuGet Package CSharpProject to 1.0.0-beta.24176.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
-    <PackageVersion Include="Microsoft.DotNet.Interactive.CSharpProject" Version="1.0.0-beta.24168.2" />
+    <PackageVersion Include="Microsoft.DotNet.Interactive.CSharpProject" Version="1.0.0-beta.24176.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.41.2" />
     <PackageVersion Include="peaky.client" Version="4.0.73" />
     <PackageVersion Include="peaky.xunit" Version="4.0.73" />


### PR DESCRIPTION
This new version contain major changes that changes the behaviour of the Build on the Server.

The server should not do builds, and this package version is using cache instead.