### PR TITLE
First steps removing Arcade build support

### DIFF
--- a/azure-pipelines-CI.yml
+++ b/azure-pipelines-CI.yml
@@ -171,15 +171,3 @@ extends:
             buildConfig: $(_BuildConfig)
             skipTests: $(SkipTests)
             additionalArgs: $(additionalLinuxArgs)
-
-    #---------------------------------------------------------------------------------------------------------------------#
-    #                                                    Post Build                                                       #
-    #---------------------------------------------------------------------------------------------------------------------#
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng/common/templates-official/post-build/post-build.yml
-        parameters:
-          publishingInfraVersion: 3
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
-          enableSourceLinkValidation: false


### PR DESCRIPTION
Removing post-build steps.  

fix: remove post-build stages as arcade is no longer needed