### PR TITLE
Update index.css removing border, fixing body rule typo

### DIFF
--- a/src/microsoft-trydotnet-editor/src/index.css
+++ b/src/microsoft-trydotnet-editor/src/index.css
@@ -1,7 +1,6 @@
-.body {
+body {
 	width: auto;
 	height: auto;
-	border: 1px solid #ccc;
 	margin: 0;
 }
 

--- a/src/microsoft-trydotnet-editor/src/index.css
+++ b/src/microsoft-trydotnet-editor/src/index.css
@@ -7,3 +7,7 @@ body {
 .monaco-editor {
 	padding: 0.5rem;
 }
+
+iframe[role="wasm-runner"] {
+    opacity: 0;
+}


### PR DESCRIPTION
Removes unnecessary border, reverts CSS rule back to target `body` HTML element. Updates body element to receive same background color treatment as editor to prevent a mismatch in dark and high contrast modes on Learn.