### PR TITLE
Update SDK and dotnet versions to 9.0.111

### DIFF
--- a/azure-pipelines-CI.yml
+++ b/azure-pipelines-CI.yml
@@ -130,10 +130,10 @@ extends:
                 value: /p:SignType=$(_SignType)
             steps:
             - task: UseDotNet@2
-              displayName: Install SDK 9.0.102
+              displayName: Install SDK 9.0.111
               inputs:
                 packageType: sdk
-                version: 9.0.102
+                version: 9.0.111
             - template: /eng/templates/build-and-test-job-windows-templates.yml@self
               parameters:
                 buildConfig: $(_BuildConfig)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,10 +78,10 @@ stages:
             value: /p:SignType=$(_SignType)
         steps:
         - task: UseDotNet@2
-          displayName: Install SDK 9.0.102
+          displayName: Install SDK 9.0.111
           inputs:
             packageType: sdk
-            version: 9.0.102
+            version: 9.0.111
         - template: /eng/templates/build-and-test-job-windows-templates.yml@self
           parameters:
             buildConfig: $(_BuildConfig)

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "9.0.102",
+    "version": "9.0.111",
     "allowPrerelease": true,
     "rollForward": "latestMinor"
   },
   "tools": {
-    "dotnet": "9.0.102",
+    "dotnet": "9.0.111",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
Another dependabot update: https://dev.azure.com/dnceng/internal/_git/dotnet-try/pullrequest/54462?_a=files. Moved to a more recent sdk version to fix additional security issues.